### PR TITLE
Add multithreading support for libbacktrace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@
 #![doc(html_root_url = "http://alexcrichton.com/backtrace-rs")]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
+#![feature(static_mutex)]
 
 extern crate libc;
 extern crate debug_builders;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@
 #![doc(html_root_url = "http://alexcrichton.com/backtrace-rs")]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
-#![feature(static_mutex)]
 
 extern crate libc;
 extern crate debug_builders;

--- a/src/symbolize/libbacktrace.rs
+++ b/src/symbolize/libbacktrace.rs
@@ -18,23 +18,15 @@ use std::env;
 use std::ffi::CStr;
 use std::path::Path;
 use std::ptr;
-use std::sync::{MUTEX_INIT, ONCE_INIT, Once, StaticMutex};
+use std::sync::{ONCE_INIT, Once};
 
 use Symbol;
 
 type FileLine = (*const c_char, c_int);
 
-extern fn error_cb(_data: *mut c_void, msg: *const c_char,
+extern fn error_cb(_data: *mut c_void, _msg: *const c_char,
                    _errnum: c_int) {
-    unsafe {
-        let msg: &[u8] = CStr::from_ptr(msg).to_bytes();
-        // Install a global mutex for libbacktrace's state, signaling
-        // that we need to try initialization with `threaded = 0`.
-        // It'd be nice if there was a better way to detect this...
-        if msg == &b"backtrace library does not support threads"[..] {
-            STATE_LOCK = Some(MUTEX_INIT);
-        }
-    }
+    // do nothing for now
 }
 
 extern fn syminfo_cb(data: *mut c_void,
@@ -140,12 +132,6 @@ unsafe fn call(data: *mut c_void, sym: &Symbol) {
 // the symbols. The libbacktrace API also states that the filename must
 // be in "permanent memory", so we copy it to a static and then use the
 // static as the pointer.
-//
-// Furthermore, libbacktrace may not be compiled with multithreading
-// support, even though we certainly want to present a thread-safe
-// interface here.  If we detect that multithreading support is
-// missing, we'll serialize access to the state via a mutex.
-static mut STATE_LOCK: Option<StaticMutex> = None;
 unsafe fn init_state() -> *mut bt::backtrace_state {
     static mut STATE: *mut bt::backtrace_state = 0 as *mut _;
     static mut LAST_FILENAME: [c_char; 256] = [0; 256];
@@ -173,14 +159,10 @@ unsafe fn init_state() -> *mut bt::backtrace_state {
             }
             None => ptr::null(),
         };
-        STATE = bt::backtrace_create_state(filename, 1, error_cb,
+        // Our libbacktrace may not have multithreading support, so
+        // set `threaded = 0` and synchronize ourselves.
+        STATE = bt::backtrace_create_state(filename, 0, error_cb,
                                            ptr::null_mut());
-        // Retry with `threaded = 0` if we failed due to a lack of
-        // multithreading support
-        if STATE.is_null() && STATE_LOCK.is_some() {
-            STATE = bt::backtrace_create_state(filename, 0, error_cb,
-                                               ptr::null_mut());
-        }
     });
 
     STATE
@@ -204,8 +186,7 @@ pub fn resolve(symaddr: *mut c_void, mut cb: &mut FnMut(&Symbol)) {
         if state.is_null() {
             return
         }
-        // Potentially serialize the remainder of this function
-        let _guard = STATE_LOCK.as_ref().map(|s| s.lock());
+        let _guard = ::lock::lock();
 
         let ret = bt::backtrace_pcinfo(state, symaddr as uintptr_t,
                                        pcinfo_cb, error_cb,

--- a/src/symbolize/libbacktrace.rs
+++ b/src/symbolize/libbacktrace.rs
@@ -18,7 +18,7 @@ use std::env;
 use std::ffi::CStr;
 use std::path::Path;
 use std::ptr;
-use std::sync::{ONCE_INIT, StaticMutex, Once};
+use std::sync::{MUTEX_INIT, ONCE_INIT, Once, StaticMutex};
 
 use Symbol;
 
@@ -26,15 +26,13 @@ type FileLine = (*const c_char, c_int);
 
 extern fn error_cb(_data: *mut c_void, msg: *const c_char,
                    _errnum: c_int) {
-
-    let s: &'static [u8] = b"backtrace library does not support threads";
     unsafe {
         let msg: &[u8] = CStr::from_ptr(msg).to_bytes();
         // Install a global mutex for libbacktrace's state, signaling
         // that we need to try initialization with `threaded = 0`.
         // It'd be nice if there was a better way to detect this...
         if msg == &b"backtrace library does not support threads"[..] {
-            STATE_LOCK = Some(StaticMutex::new());
+            STATE_LOCK = Some(MUTEX_INIT);
         }
     }
 }


### PR DESCRIPTION
Our previous usage of libbacktrace wasn't thread-safe since it passed `threaded = 0` to `backtrace_create_state`, which then requires all library calls to be serialized.  It's pretty easy to get a segfault by calling into the `backtrace` library across multiple threads:

```rust
#![feature(drain)]
extern crate backtrace;

use std::str;
use std::thread;

fn iter() {
    for _ in (0..16) {
        backtrace::trace(&mut |frame| {
            backtrace::resolve(frame.ip(), &mut |symbol| {
                symbol.name().and_then(|s| str::from_utf8(s).ok()).map(|name| {
                    let mut demangled = String::new();
                    backtrace::demangle(&mut demangled, name).unwrap();
                    println!("{}", demangled);
                });
            });
            true
        });
    }
}

fn main() {
    let mut threads: Vec<_> = (0..16)
        .map(|_| thread::spawn(iter))
        .collect();

    for t in threads.drain(..) {
        t.join().unwrap()
    }
}
```

This patch adds a `StaticMutex` fallback for when we detect that libbacktrace isn't thread-safe.