### PR TITLE
Bump to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backtrace"
-version = "0.1.6"
+version = "0.2.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>",
            "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
@@ -14,10 +14,10 @@ A library to acquire a stack trace (backtrace) at runtime in a Rust program.
 
 [dependencies]
 libc = "0.2"
-backtrace-sys = { path = "backtrace-sys", version = "0.1", optional = true }
-kernel32-sys = { version = "0.1", optional = true }
+backtrace-sys = { path = "backtrace-sys", version = "0.2", optional = true }
+kernel32-sys = { version = "0.2", optional = true }
 winapi = { version = "0.2", optional = true }
-dbghelp-sys = { version = "0.1", optional = true }
+dbghelp-sys = { version = "0.2", optional = true }
 cfg-if = "0.1"
 debug-builders = "0.1"
 

--- a/backtrace-sys/Cargo.toml
+++ b/backtrace-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backtrace-sys"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 build = "build.rs"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
- Updated dependencies

The `Frame` trait exposes `c_void`.