### PR TITLE
Implemented basic support for core symbolication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ winapi = { version = "0.2.5", optional = true }
 dbghelp-sys = { version = "0.2", optional = true }
 cfg-if = "0.1"
 rustc-demangle = "0.1"
-shared_library = { version = "0.1.5", optional = true }
 
 # Optionally enable the ability to serialize a `Backtrace`
 serde = { version = "0.8", optional = true }
@@ -76,7 +75,7 @@ default = ["libunwind", "libbacktrace", "coresymbolication", "dladdr", "dbghelp"
     #   framework on OS X to symbolize.
     libbacktrace = ["backtrace-sys"]
     dladdr = []
-    coresymbolication = ["shared_library"]
+    coresymbolication = []
 
     #=======================================
     # Methods of serialization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde_codegen = { version = "0.8", optional = true }
 # Note that not all features are available on all platforms, so even though a
 # feature is enabled some other feature may be used instead.
 [features]
-default = ["libunwind", "libbacktrace", "dladdr", "dbghelp"]
+default = ["libunwind", "libbacktrace", "coresymbolication", "dladdr", "dbghelp"]
 
     #=======================================
     # Methods of acquiring a backtrace
@@ -70,9 +70,11 @@ default = ["libunwind", "libbacktrace", "dladdr", "dbghelp"]
     # - dladdr: this feature uses the dladdr(3) function (a glibc extension) to
     #   resolve symbol names. This is fairly unreliable on linux, but works well
     #   enough on OSX.
+    # - coresymbolication: this feature uses the undocumented core symbolication
+    #   framework on OS X to symbolize.
     libbacktrace = ["backtrace-sys"]
     dladdr = []
-
+    coresymbolication = []
 
     #=======================================
     # Methods of serialization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ winapi = { version = "0.2.5", optional = true }
 dbghelp-sys = { version = "0.2", optional = true }
 cfg-if = "0.1"
 rustc-demangle = "0.1"
+shared_library = { version = "0.1.5", optional = true }
 
 # Optionally enable the ability to serialize a `Backtrace`
 serde = { version = "0.8", optional = true }
@@ -74,7 +75,7 @@ default = ["libunwind", "libbacktrace", "coresymbolication", "dladdr", "dbghelp"
     #   framework on OS X to symbolize.
     libbacktrace = ["backtrace-sys"]
     dladdr = []
-    coresymbolication = []
+    coresymbolication = ["shared_library"]
 
     #=======================================
     # Methods of serialization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2"
-lazy_static = "0.2"
+lazy_static = { version = "0.2", optional = true }
 backtrace-sys = { path = "backtrace-sys", version = "0.1.3", optional = true }
 kernel32-sys = { version = "0.2", optional = true }
 winapi = { version = "0.2.5", optional = true }
@@ -75,7 +75,7 @@ default = ["libunwind", "libbacktrace", "coresymbolication", "dladdr", "dbghelp"
     #   framework on OS X to symbolize.
     libbacktrace = ["backtrace-sys"]
     dladdr = []
-    coresymbolication = []
+    coresymbolication = ["lazy_static"]
 
     #=======================================
     # Methods of serialization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2"
+lazy_static = "0.2"
 backtrace-sys = { path = "backtrace-sys", version = "0.1.3", optional = true }
 kernel32-sys = { version = "0.2", optional = true }
 winapi = { version = "0.2.5", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -23,10 +23,6 @@ fn main() {
         fs::copy("src/capture.rs", out_dir.join("capture.rs")).unwrap();
     }
 
-    if cfg!(feature = "coresymbolication") {
-        println!("cargo:rustc-link-search=framework=/System/Library/PrivateFrameworks/");
-    }
-
     expand_serde(out_dir);
     println!("cargo:rerun-if-changed=src/capture.rs");
 }

--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,10 @@ fn main() {
         fs::copy("src/capture.rs", out_dir.join("capture.rs")).unwrap();
     }
 
+    if cfg!(feature = "coresymbolication") {
+        println!("cargo:rustc-link-search=framework=/System/Library/PrivateFrameworks/");
+    }
+
     expand_serde(out_dir);
     println!("cargo:rerun-if-changed=src/capture.rs");
 }

--- a/src/dylib.rs
+++ b/src/dylib.rs
@@ -1,0 +1,89 @@
+#![macro_use]
+
+use std::ffi::CString;
+use libc::{dlopen, dlsym, dlclose, c_void};
+
+
+/// Simple implementation of dynamic library loading.  We're using
+/// this for loading debug support on OS X at runtime since we're
+/// using a private framework there which might not be there or
+/// disappear.  See `symbolize/coresymbolication` for how this is used.
+pub struct Dylib {
+    handle: *mut c_void,
+}
+
+unsafe impl Sync for Dylib {}
+
+impl Dylib {
+    pub fn open(path: &str) -> Dylib {
+        let path = CString::new(path).unwrap();
+        unsafe {
+            Dylib {
+                handle: dlopen(path.as_ptr() as *const _, 1)
+            }
+        }
+    }
+
+    pub fn is_available(&self) -> bool {
+        !self.handle.is_null()
+    }
+
+    pub unsafe fn load_symbol(&self, sym: &str) -> *mut c_void {
+        let name = CString::new(sym).unwrap();
+        dlsym(self.handle, name.as_ptr() as *const _)
+    }
+}
+
+impl Drop for Dylib {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe {
+                dlclose(self.handle);
+            }
+        }
+    }
+}
+
+
+macro_rules! load_dynamically {
+    (@as_item $i:item) => { $i };
+    (
+        #[link=$lib:tt]
+        extern $cconv:tt as $libname:ident {
+            $(
+                fn $funcname:ident($($argnames:ident: $argtypes:ty),*)
+                    -> $rv:ty;
+            )*
+        }
+    ) => {
+        lazy_static! {
+            static ref $libname: ::dylib::Dylib = ::dylib::Dylib::open($lib);
+        }
+
+        $(
+            load_dynamically! {
+                @as_item
+                #[allow(non_snake_case)]
+                unsafe fn $funcname($($argnames: $argtypes),*) -> $rv {
+                    #![allow(dead_code)]
+                    lazy_static! {
+                        static ref FN: unsafe extern $cconv fn($($argtypes),*) -> $rv = {
+                            unsafe {
+                                if !$libname.is_available() {
+                                    panic!("Library {} is not available", $lib);
+                                }
+                                let ptr = $libname.load_symbol(stringify!($funcname));
+                                if ptr.is_null() {
+                                    panic!("Symbol {} not found in {}",
+                                           stringify!($funcname), $lib);
+                                }
+                                ::std::mem::transmute(ptr)
+                            }
+                        };
+                    }
+                    (FN)($($argnames),*)
+                }
+            }
+        )*
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ extern crate cfg_if;
 extern crate rustc_demangle;
 
 // this has some macros
-#[cfg(all(feature = "coresymbolication", target_os="macos"))]
+#[cfg(all(feature = "coresymbolication", target_os = "macos"))]
 mod dylib;
 
 pub use backtrace::{trace, Frame};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 //!
 //! This library makes use of a number of strategies for actually acquiring a
 //! backtrace. For example unix uses libgcc's libunwind bindings by default to
-//! acquire a backtrace, but dladdr is used on OSX to acquire symbol names while
-//! linux uses gcc's libbacktrace.
+//! acquire a backtrace, but coresymbolication or dladdr is used on OSX to
+//! acquire symbol names while linux uses gcc's libbacktrace.
 //!
 //! When using the default feature set of this library the "most reasonable" set
 //! of defaults is chosen for the current platform, but the features activated

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,10 @@ extern crate libc;
 #[cfg(feature = "winapi")] extern crate winapi;
 #[cfg(feature = "dbghelp")] extern crate dbghelp;
 
+#[macro_use]
+#[cfg(all(feature = "coresymbolication", target_os = "macos"))]
+extern crate shared_library;
+
 #[cfg(feature = "serde")]
 extern crate serde;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,14 +69,11 @@
 #![deny(missing_docs)]
 // #![cfg_attr(test, deny(warnings))]
 
+#[macro_use] extern crate lazy_static;
 extern crate libc;
 #[cfg(feature = "kernel32-sys")] extern crate kernel32;
 #[cfg(feature = "winapi")] extern crate winapi;
 #[cfg(feature = "dbghelp")] extern crate dbghelp;
-
-#[macro_use]
-#[cfg(all(feature = "coresymbolication", target_os = "macos"))]
-extern crate shared_library;
 
 #[cfg(feature = "serde")]
 extern crate serde;
@@ -88,6 +85,9 @@ extern crate rustc_serialize;
 extern crate cfg_if;
 
 extern crate rustc_demangle;
+
+// this has some macros
+mod dylib;
 
 pub use backtrace::{trace, Frame};
 mod backtrace;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,10 @@
 #![deny(missing_docs)]
 // #![cfg_attr(test, deny(warnings))]
 
-#[macro_use] extern crate lazy_static;
+#[cfg(all(feature = "coresymbolication", target_os="macos"))]
+#[macro_use]
+extern crate lazy_static;
+
 extern crate libc;
 #[cfg(feature = "kernel32-sys")] extern crate kernel32;
 #[cfg(feature = "winapi")] extern crate winapi;
@@ -87,6 +90,7 @@ extern crate cfg_if;
 extern crate rustc_demangle;
 
 // this has some macros
+#[cfg(all(feature = "coresymbolication", target_os="macos"))]
 mod dylib;
 
 pub use backtrace::{trace, Frame};

--- a/src/symbolize/coresymbolication.rs
+++ b/src/symbolize/coresymbolication.rs
@@ -1,0 +1,131 @@
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::os::raw::{c_void, c_char, c_int};
+use std::ffi::{CStr, OsStr};
+use std::path::Path;
+use std::os::unix::prelude::*;
+use std::ptr;
+use libc::getpid;
+
+use {Symbol, SymbolName};
+
+#[repr(C)]
+#[derive(Copy, Clone, PartialEq)]
+struct CSTypeRef {
+    cpp_data: *const c_void,
+    cpp_obj: *const c_void
+}
+
+const CS_NOW: u64 = 0x80000000;
+const CSREF_NULL: CSTypeRef = CSTypeRef {
+    cpp_data: 0 as *const c_void,
+    cpp_obj: 0 as *const c_void,
+};
+
+#[repr(C)]
+struct Info {
+    path: *const c_char,
+    lineno: u32,
+    name: *const c_char,
+    addr: *mut c_void,
+}
+
+impl Symbol for Info {
+    fn name(&self) -> Option<SymbolName> {
+        if self.name.is_null() {
+            None
+        } else {
+            Some(SymbolName::new(unsafe {
+                CStr::from_ptr(self.name).to_bytes()
+            }))
+        }
+    }
+
+    fn addr(&self) -> Option<*mut c_void> {
+        Some(self.addr)
+    }
+
+    fn filename(&self) -> Option<&Path> {
+        if self.path.is_null() {
+            None
+        } else {
+            Some(Path::new(OsStr::from_bytes(unsafe {
+                CStr::from_ptr(self.path).to_bytes()
+            })))
+        }
+    }
+
+    fn lineno(&self) -> Option<u32> {
+        if self.lineno == 0 {
+            None
+        } else {
+            Some(self.lineno)
+        }
+    }
+}
+
+#[link(name="CoreSymbolication", kind="framework")]
+extern {
+    fn CSSymbolicatorCreateWithPid(pid: c_int) -> CSTypeRef;
+    fn CSRelease(rf: CSTypeRef);
+    fn CSSymbolicatorGetSymbolWithAddressAtTime(
+        cs: CSTypeRef, addr: *const c_void, time: u64) -> CSTypeRef;
+    fn CSSymbolicatorGetSourceInfoWithAddressAtTime(
+        cs: CSTypeRef, addr: *const c_void, time: u64) -> CSTypeRef;
+    fn CSSourceInfoGetLineNumber(info: CSTypeRef) -> c_int;
+    fn CSSourceInfoGetPath(info: CSTypeRef) -> *const c_char;
+    fn CSSourceInfoGetSymbol(info: CSTypeRef) -> CSTypeRef;
+    fn CSSymbolGetName(sym: CSTypeRef) -> *const c_char;
+    fn CSSymbolGetSymbolOwner(sym: CSTypeRef) -> CSTypeRef;
+    fn CSSymbolOwnerGetBaseAddress(symowner: CSTypeRef) -> *mut c_void;
+}
+
+pub fn resolve(addr: *mut c_void, cb: &mut FnMut(&Symbol)) {
+    unsafe {
+        let cs = CSSymbolicatorCreateWithPid(getpid());
+        if cs == CSREF_NULL {
+            return;
+        }
+
+        let info = CSSymbolicatorGetSourceInfoWithAddressAtTime(cs, addr, CS_NOW);
+        let sym = if info == CSREF_NULL {
+            CSSymbolicatorGetSymbolWithAddressAtTime(cs, addr, CS_NOW)
+        } else {
+            CSSourceInfoGetSymbol(info)
+        };
+
+        if sym == CSREF_NULL {
+            return;
+        }
+
+        let owner = CSSymbolGetSymbolOwner(sym);
+        if owner == CSREF_NULL {
+            return;
+        }
+
+        cb(&Info {
+            path: if info != CSREF_NULL {
+                CSSourceInfoGetPath(info)
+            } else {
+                ptr::null()
+            },
+            lineno: if info != CSREF_NULL {
+                CSSourceInfoGetLineNumber(info) as u32
+            } else {
+                0
+            },
+            name: CSSymbolGetName(sym),
+            addr: CSSymbolOwnerGetBaseAddress(owner),
+        });
+
+        CSRelease(cs);
+    }
+}

--- a/src/symbolize/coresymbolication.rs
+++ b/src/symbolize/coresymbolication.rs
@@ -102,29 +102,25 @@ pub fn resolve(addr: *mut c_void, cb: &mut FnMut(&Symbol)) {
             CSSourceInfoGetSymbol(info)
         };
 
-        if sym == CSREF_NULL {
-            return;
+        if sym != CSREF_NULL {
+            let owner = CSSymbolGetSymbolOwner(sym);
+            if owner != CSREF_NULL {
+                cb(&Info {
+                    path: if info != CSREF_NULL {
+                        CSSourceInfoGetPath(info)
+                    } else {
+                        ptr::null()
+                    },
+                    lineno: if info != CSREF_NULL {
+                        CSSourceInfoGetLineNumber(info) as u32
+                    } else {
+                        0
+                    },
+                    name: CSSymbolGetName(sym),
+                    addr: CSSymbolOwnerGetBaseAddress(owner),
+                });
+            }
         }
-
-        let owner = CSSymbolGetSymbolOwner(sym);
-        if owner == CSREF_NULL {
-            return;
-        }
-
-        cb(&Info {
-            path: if info != CSREF_NULL {
-                CSSourceInfoGetPath(info)
-            } else {
-                ptr::null()
-            },
-            lineno: if info != CSREF_NULL {
-                CSSourceInfoGetLineNumber(info) as u32
-            } else {
-                0
-            },
-            name: CSSymbolGetName(sym),
-            addr: CSSymbolOwnerGetBaseAddress(owner),
-        });
 
         CSRelease(cs);
     }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -152,7 +152,7 @@ cfg_if! {
                         not(target_os = "macos")))] {
         mod libbacktrace;
         use self::libbacktrace::resolve as resolve_imp;
-    } else if #[cfg(all(feature = "coresymbolication", unix,
+    } else if #[cfg(all(feature = "coresymbolication",
                         target_os = "macos"))] {
         mod coresymbolication;
         use self::coresymbolication::resolve as resolve_imp;

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -152,6 +152,10 @@ cfg_if! {
                         not(target_os = "macos")))] {
         mod libbacktrace;
         use self::libbacktrace::resolve as resolve_imp;
+    } else if #[cfg(all(feature = "coresymbolication", unix,
+                        target_os = "macos"))] {
+        mod coresymbolication;
+        use self::coresymbolication::resolve as resolve_imp;
     } else if #[cfg(all(unix, feature = "dladdr"))] {
         mod dladdr;
         use self::dladdr::resolve as resolve_imp;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -7,6 +7,8 @@ static LIBUNWIND: bool = cfg!(all(unix, feature = "libunwind"));
 static UNIX_BACKTRACE: bool = cfg!(all(unix, feature = "unix-backtrace"));
 static LIBBACKTRACE: bool = cfg!(all(unix, feature = "libbacktrace")) &&
                             !cfg!(target_os = "macos");
+static CORESYMBOLICATION: bool = cfg!(all(unix, target_os = "macos",
+                                          feature = "coresymbolication"));
 static DLADDR: bool = cfg!(all(unix, feature = "dladdr"));
 static DBGHELP: bool = cfg!(all(windows, feature = "dbghelp"));
 static MSVC: bool = cfg!(target_env = "msvc");
@@ -69,7 +71,7 @@ fn smoke_test_frames() {
         }
 
         let mut resolved = 0;
-        let can_resolve = DLADDR || LIBBACKTRACE || DBGHELP;
+        let can_resolve = DLADDR || LIBBACKTRACE || CORESYMBOLICATION || DBGHELP;
 
         let mut name = None;
         let mut addr = None;
@@ -104,7 +106,7 @@ fn smoke_test_frames() {
             addr.expect("didn't find a symbol");
         }
 
-        if (LIBBACKTRACE || (DBGHELP && MSVC)) && cfg!(debug_assertions) {
+        if (LIBBACKTRACE || CORESYMBOLICATION || (DBGHELP && MSVC)) && cfg!(debug_assertions) {
             let line = line.expect("didn't find a line number");
             let file = file.expect("didn't find a line number");
             if !expected_file.is_empty() {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -7,7 +7,7 @@ static LIBUNWIND: bool = cfg!(all(unix, feature = "libunwind"));
 static UNIX_BACKTRACE: bool = cfg!(all(unix, feature = "unix-backtrace"));
 static LIBBACKTRACE: bool = cfg!(all(unix, feature = "libbacktrace")) &&
                             !cfg!(target_os = "macos");
-static CORESYMBOLICATION: bool = cfg!(all(unix, target_os = "macos",
+static CORESYMBOLICATION: bool = cfg!(all(target_os = "macos",
                                           feature = "coresymbolication"));
 static DLADDR: bool = cfg!(all(unix, feature = "dladdr"));
 static DBGHELP: bool = cfg!(all(windows, feature = "dbghelp"));


### PR DESCRIPTION
This adds very basic support for core symbolication which means that we get proper filenames and line numbers on OS X.

~~The main issue I have with the current implementation is that it links against a private framework. It would probably be better loading the framework at runtime and falling back to dladdr in case it cannot be found.~~

Thoughts?