### PR TITLE
Mutable API for Backtrace

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::mem;
 use std::os::raw::c_void;
 use std::path::{Path, PathBuf};
+use std::convert::{From, Into};
 
 use {trace, resolve, Frame, Symbol, SymbolName};
 
@@ -104,6 +105,20 @@ impl Backtrace {
     /// function started.
     pub fn frames(&self) -> &[BacktraceFrame] {
         &self.frames
+    }
+}
+
+impl From<Vec<BacktraceFrame>> for Backtrace {
+    fn from(frames: Vec<BacktraceFrame>) -> Self {
+        Backtrace {
+            frames: frames
+        }
+    }
+}
+
+impl Into<Vec<BacktraceFrame>> for Backtrace {
+    fn into(self) -> Vec<BacktraceFrame> {
+        self.frames
     }
 }
 


### PR DESCRIPTION
Hi,
I would like to be able to skip the first two captured frames, as those are rather uninformative, and possibly also the last, which in my case always gets displayed as `0x0 - <unknown>`.

In order to do so without re-implementing Backtrace struct, there needs to be a public API to either get a mutable reference for the frames vector, like:
```
impl Backtrace { 
  //...
  pub fn frames_mut(&mut self) -> &mut Vec<BacktraceFrame> {
    &mut self.frames
  }
}
``` 
or at least a custom constructor to produce Backtrace with frames, like: 
```
impl Backtrace {
  // ...
  pub fn with_frames(frames: Vec<BacktraceFrame>) -> Backtrace {
    Backtrace { frames: frames }
  }
}
```

In this PR I have prepared both variants, please consider adding at least one of them.

Regards,
Jakub