### PR TITLE
Try harder to find cross-compile build tools

### DIFF
--- a/backtrace-sys/build.rs
+++ b/backtrace-sys/build.rs
@@ -25,7 +25,7 @@ fn try_tool(compiler: &gcc::Tool, cc: &str, compiler_suffix: &str, tool_suffix: 
 
 fn find_tool(compiler: &gcc::Tool, cc: &str, tool: &str) -> PathBuf {
     let tool_suffix = format!("-{}", tool);
-    try_tool(compiler, cc, "-gcc", &tool_suffix).unwrap_or(PathBuf::from(tool))
+    try_tool(compiler, cc, "-gcc", &tool_suffix).or_else(|| try_tool(compiler, cc, "-cc", &tool_suffix)).unwrap_or(PathBuf::from(tool))
 }
 
 fn main() {

--- a/backtrace-sys/build.rs
+++ b/backtrace-sys/build.rs
@@ -25,7 +25,9 @@ fn try_tool(compiler: &gcc::Tool, cc: &str, compiler_suffix: &str, tool_suffix: 
 
 fn find_tool(compiler: &gcc::Tool, cc: &str, tool: &str) -> PathBuf {
     let tool_suffix = format!("-{}", tool);
-    try_tool(compiler, cc, "-gcc", &tool_suffix).or_else(|| try_tool(compiler, cc, "-cc", &tool_suffix)).unwrap_or(PathBuf::from(tool))
+    try_tool(compiler, cc, "-gcc", &tool_suffix)
+        .or_else(|| try_tool(compiler, cc, "-cc", &tool_suffix))
+        .unwrap_or_else(|| PathBuf::from(tool))
 }
 
 fn main() {

--- a/backtrace-sys/build.rs
+++ b/backtrace-sys/build.rs
@@ -14,6 +14,20 @@ macro_rules! t {
     })
 }
 
+fn try_tool(compiler: &gcc::Tool, cc: &str, compiler_suffix: &str, tool_suffix: &str) -> Option<PathBuf> {
+    if cc.ends_with(compiler_suffix) {
+        let candidate = compiler.path().parent().unwrap().join(cc.replace(compiler_suffix, tool_suffix));
+        Command::new(&candidate).output().ok().map(|_| candidate)
+    } else {
+        None
+    }
+}
+
+fn find_tool(compiler: &gcc::Tool, cc: &str, tool: &str) -> PathBuf {
+    let tool_suffix = format!("-{}", tool);
+    try_tool(compiler, cc, "-gcc", &tool_suffix).unwrap_or(PathBuf::from(tool))
+}
+
 fn main() {
     let src = env::current_dir().unwrap();
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -45,17 +59,7 @@ fn main() {
         }
         flags.push(flag);
     }
-    let ar = if cc.ends_with("-gcc") {
-        let candidate = compiler.path().parent().unwrap()
-                                .join(cc.replace("-gcc", "-ar"));
-        if Command::new(&candidate).output().is_ok() {
-            candidate
-        } else {
-            PathBuf::from("ar")
-        }
-    } else {
-        PathBuf::from("ar")
-    };
+    let ar = find_tool(&compiler, cc, "ar");
     run(Command::new(src.join("src/libbacktrace/configure"))
                 .current_dir(&dst)
                 .env("CC", compiler.path())
@@ -89,17 +93,7 @@ fn main() {
 
     t!(fs::remove_file(&lib));
     let mut objs = Vec::new();
-    let objcopy = if cc.ends_with("-gcc") {
-        let candidate = compiler.path().parent().unwrap()
-                                .join(cc.replace("-gcc", "-objcopy"));
-        if Command::new(&candidate).output().is_ok() {
-            candidate
-        } else {
-            PathBuf::from("objcopy")
-        }
-    } else {
-        PathBuf::from("objcopy")
-    };
+    let objcopy = find_tool(&compiler, cc, "objcopy");
     for obj in t!(tmpdir.read_dir()) {
         let obj = t!(obj);
         run(Command::new(&objcopy)


### PR DESCRIPTION
On exherbo, eveything including the native host is cross-compiled and "unprefixed" toolchain is banned by the package manager, so ar and objcopy are not available.
Furthermore, we allow people to chose their system compiler and thus we don't set e.g. CC=x86_64-pc-linux-gnu-gcc but CC=x86_64-pc-linux-gnu-cc
cc is a pretty standard name for the system C compiler, thus I think this would be a good idea to check using "cc" too, and not just "gcc"