### PR TITLE
Use $OBJCOPY environment var if present

### DIFF
--- a/backtrace-sys/build.rs
+++ b/backtrace-sys/build.rs
@@ -100,7 +100,13 @@ fn main() {
 
     t!(fs::remove_file(&lib));
     let mut objs = Vec::new();
-    let objcopy = find_tool(&compiler, cc, "objcopy");
+    // yocto/ openembedded provide a OBJCOPY environment var. Use these or get from cc
+    let objcopy;
+    if let Ok(var) = env::var("OBJCOPY") {
+        objcopy = PathBuf::from(var);
+    } else {
+        objcopy = find_tool(&compiler, cc, "objcopy");
+    }
     for obj in t!(tmpdir.read_dir()) {
         let obj = t!(obj);
         run(Command::new(&objcopy)


### PR DESCRIPTION
Quick n dirty fix to build the crate in yocto/ openembedded environments.

See here https://github.com/rust-embedded/meta-rust-bin/issues/16 and https://github.com/alexcrichton/backtrace-rs/issues/25#issuecomment-279742551