### PR TITLE
Add support for demangling C++ frames' symbols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
   - cargo test --no-default-features --features 'serialize-serde'
   - cargo test --no-default-features --features 'serialize-rustc'
   - cargo test --no-default-features --features 'serialize-rustc serialize-serde'
+  - cd ./cpp_smoke_test && cargo test && cd ..
   - cargo clean && cargo build
   - rustdoc --test README.md -L target/debug/deps -L target/debug
   - cargo doc --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,14 @@ build = "build.rs"
 [dependencies]
 libc = "0.2"
 cfg-if = "0.1"
-rustc-demangle = "0.1"
+rustc-demangle = "0.1.4"
 
 # Optionally enable the ability to serialize a `Backtrace`
 serde = { version = "0.8", optional = true }
 rustc-serialize = { version = "0.3", optional = true }
+
+# Optionally demangle C++ frames' symbols in backtraces.
+cpp_demangle = { version = "0.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 dbghelp-sys = { version = "0.2", optional = true }
@@ -42,7 +45,7 @@ serde_codegen = { version = "0.8", optional = true }
 # Note that not all features are available on all platforms, so even though a
 # feature is enabled some other feature may be used instead.
 [features]
-default = ["libunwind", "libbacktrace", "coresymbolication", "dladdr", "dbghelp"]
+default = ["libunwind", "libbacktrace", "coresymbolication", "dladdr", "dbghelp", "cpp_demangle"]
 
     #=======================================
     # Methods of acquiring a backtrace

--- a/cpp_smoke_test/Cargo.toml
+++ b/cpp_smoke_test/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "cpp_smoke_test"
+version = "0.1.0"
+authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
+build = "build.rs"
+
+[build-dependencies]
+gcc = "0.3.43"
+
+[dependencies]
+"backtrace" = { path = ".." }

--- a/cpp_smoke_test/build.rs
+++ b/cpp_smoke_test/build.rs
@@ -1,0 +1,16 @@
+extern crate gcc;
+
+fn main() {
+    compile_cpp();
+}
+
+fn compile_cpp() {
+    println!("cargo:rerun-if-changed=cpp/trampoline.cpp");
+
+    gcc::Config::new()
+        .cpp(true)
+        .debug(true)
+        .opt_level(0)
+        .file("cpp/trampoline.cpp")
+        .compile("libcpptrampoline.a");
+}

--- a/cpp_smoke_test/cpp/trampoline.cpp
+++ b/cpp_smoke_test/cpp/trampoline.cpp
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+namespace space {
+    template <typename FuncT>
+    void templated_trampoline(FuncT func) {
+        func();
+    }
+}
+
+typedef void (*FuncPtr)();
+
+extern "C" void cpp_trampoline(FuncPtr func) {
+    space::templated_trampoline(func);
+}

--- a/cpp_smoke_test/src/lib.rs
+++ b/cpp_smoke_test/src/lib.rs
@@ -1,0 +1,3 @@
+#[test]
+fn it_works() {
+}

--- a/cpp_smoke_test/tests/smoke.rs
+++ b/cpp_smoke_test/tests/smoke.rs
@@ -1,0 +1,70 @@
+extern crate cpp_smoke_test;
+extern crate backtrace;
+
+use std::sync::atomic::{ATOMIC_BOOL_INIT, AtomicBool, Ordering};
+
+extern "C" {
+    fn cpp_trampoline(func: extern "C" fn()) -> ();
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn smoke_test_cpp() {
+    static RAN_ASSERTS: AtomicBool = ATOMIC_BOOL_INIT;
+
+    extern "C" fn assert_cpp_frames() {
+        let mut physical_frames = Vec::new();
+        backtrace::trace(|cx| {
+            physical_frames.push(cx.ip());
+
+            // We only want to capture this closure's frame, assert_cpp_frames,
+            // space::templated_trampoline, and cpp_trampoline. Those are
+            // logical frames, which might be inlined into fewer physical
+            // frames, so we may end up with extra logical frames after
+            // resolving these.
+            physical_frames.len() < 4
+        });
+
+        let names: Vec<_> = physical_frames.into_iter()
+            .flat_map(|ip| {
+                let mut logical_frame_names = vec![];
+
+                backtrace::resolve(ip, |sym| {
+                    let sym_name = sym.name().expect("Should have a symbol name");
+                    let demangled = sym_name.to_string();
+                    logical_frame_names.push(demangled);
+                });
+
+                assert!(!logical_frame_names.is_empty(),
+                        "Should have resolved at least one symbol for the physical frame");
+
+                logical_frame_names
+            })
+            // Skip the backtrace::trace closure and assert_cpp_frames, and then
+            // take the two C++ frame names.
+            .skip_while(|name| !name.contains("trampoline"))
+            .take(2)
+            .collect();
+
+        println!("actual names = {:#?}", names);
+
+        let expected = [
+            "void space::templated_trampoline<void (*)()>(void (*)())",
+            "cpp_trampoline",
+        ];
+        println!("expected names = {:#?}", expected);
+
+        assert_eq!(names.len(), expected.len());
+        for (actual, expected) in names.iter().zip(expected.iter()) {
+            assert_eq!(actual, expected);
+        }
+
+        RAN_ASSERTS.store(true, Ordering::SeqCst);
+    }
+
+    assert!(!RAN_ASSERTS.load(Ordering::SeqCst));
+    unsafe {
+        cpp_trampoline(assert_cpp_frames);
+    }
+    assert!(RAN_ASSERTS.load(Ordering::SeqCst));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,9 @@ extern crate cfg_if;
 
 extern crate rustc_demangle;
 
+#[cfg(feature = "cpp_demangle")]
+extern crate cpp_demangle;
+
 #[allow(dead_code)] // not used everywhere
 #[cfg(unix)]
 #[macro_use]


### PR DESCRIPTION
This adds a new optional (but on-by-default) dependency on the `cpp_demangle` crate. When this feature is enabled, if demangling a frame's symbol as a Rust symbol fails, then we attempt to demangle it as a C++ symbol.

r? @alexcrichton 

I didn't add any tests because I am lazy. Don't hesitate to push back on this if you feel it needs testing.