### PR TITLE
Add possibility to create a lazy backtrace.

### DIFF
--- a/src/backtrace/dbghelp.rs
+++ b/src/backtrace/dbghelp.rs
@@ -14,6 +14,7 @@ use std::mem;
 use winapi::*;
 use kernel32;
 
+#[derive(Clone)]
 pub struct Frame {
     inner: STACKFRAME64,
 }

--- a/src/backtrace/libunwind.rs
+++ b/src/backtrace/libunwind.rs
@@ -10,6 +10,7 @@
 
 use std::os::raw::c_void;
 
+#[derive(Clone)]
 pub struct Frame {
     ctx: *mut uw::_Unwind_Context,
 }

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -48,6 +48,7 @@ pub fn trace<F: FnMut(&Frame) -> bool>(mut cb: F) {
 /// The tracing function's closure will be yielded frames, and the frame is
 /// virtually dispatched as the underlying implementation is not always known
 /// until runtime.
+#[derive(Clone)]
 pub struct Frame {
     inner: FrameImp,
 }

--- a/src/backtrace/noop.rs
+++ b/src/backtrace/noop.rs
@@ -3,6 +3,7 @@ use std::os::raw::c_void;
 #[inline(always)]
 pub fn trace(_cb: &mut FnMut(&super::Frame) -> bool) {}
 
+#[derive(Clone)]
 pub struct Frame;
 
 impl Frame {

--- a/src/backtrace/unix_backtrace.rs
+++ b/src/backtrace/unix_backtrace.rs
@@ -11,6 +11,7 @@
 use std::mem;
 use std::os::raw::{c_void, c_int};
 
+#[derive(Clone)]
 pub struct Frame {
     addr: *mut c_void,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ mod backtrace;
 pub use symbolize::{resolve, Symbol, SymbolName};
 mod symbolize;
 
-pub use capture::{Backtrace, BacktraceFrame, BacktraceSymbol};
+pub use capture::{Backtrace, BacktraceFrame, BacktraceSymbol, LazyBacktrace};
 mod capture {
     include!(concat!(env!("OUT_DIR"), "/capture.rs"));
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -3,6 +3,8 @@ extern crate backtrace;
 use std::os::raw::c_void;
 use std::thread;
 
+use backtrace::{Backtrace, LazyBacktrace};
+
 static LIBUNWIND: bool = cfg!(all(unix, feature = "libunwind"));
 static UNIX_BACKTRACE: bool = cfg!(all(unix, feature = "unix-backtrace"));
 static LIBBACKTRACE: bool = cfg!(all(unix, feature = "libbacktrace")) &&
@@ -140,6 +142,11 @@ fn many_threads() {
     for t in threads {
         t.join().unwrap()
     }
+}
+
+#[test]
+fn lazy() {
+    let _backtrace: Backtrace = LazyBacktrace::new().resolve();
 }
 
 #[test]


### PR DESCRIPTION
    #[bench]
    fn b(b: &mut Bencher) {
        b.iter(|| backtrace::Backtrace::new());
    }

    #[bench]
    fn c(b: &mut Bencher) {
        b.iter(|| backtrace::LazyBacktrace::new());
    }

`c()` is three times as fast as `b()`.