### PR TITLE
Bump to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backtrace"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>",
            "The Rust Project Developers"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This will bring target-specific dependencies https://github.com/alexcrichton/backtrace-rs/pull/23

Many crates uses error-chain, and error-chain depends on backtrace. Using target-specific dependencies will allow this crates to be build faster.