### PR TITLE
Fix nightly error due to unused_macros lint

### DIFF
--- a/src/dylib.rs
+++ b/src/dylib.rs
@@ -68,16 +68,3 @@ unsafe fn fetch(handle: *mut c_void, name: *const u8) -> usize {
         ptr as usize
     }
 }
-
-macro_rules! dlsym {
-    (extern {
-        $(fn $name:ident($($arg:ident: $t:ty),*) -> $ret:ty;)*
-    }) => ($(
-        static $name: ::dylib::Symbol<unsafe extern fn($($t),*) -> $ret> =
-            ::dylib::Symbol {
-                name: concat!(stringify!($name), "\0"),
-                addr: ::std::sync::atomic::ATOMIC_USIZE_INIT,
-                _marker: ::std::marker::PhantomData,
-            };
-    )*)
-}

--- a/src/symbolize/coresymbolication.rs
+++ b/src/symbolize/coresymbolication.rs
@@ -95,6 +95,19 @@ impl Symbol {
 
 static CORESYMBOLICATION: Dylib = Dylib { init: ATOMIC_USIZE_INIT };
 
+macro_rules! dlsym {
+    (extern {
+        $(fn $name:ident($($arg:ident: $t:ty),*) -> $ret:ty;)*
+    }) => ($(
+        static $name: ::dylib::Symbol<unsafe extern fn($($t),*) -> $ret> =
+            ::dylib::Symbol {
+                name: concat!(stringify!($name), "\0"),
+                addr: ::std::sync::atomic::ATOMIC_USIZE_INIT,
+                _marker: ::std::marker::PhantomData,
+            };
+    )*)
+}
+
 dlsym! {
     extern {
         fn CSSymbolicatorCreateWithPid(pid: c_int) -> CSTypeRef;


### PR DESCRIPTION
We could annotate `macro_rules! dlsym` itself with the appropriate cfg attributes, but I think this is cleaner.