### PR TITLE
On FreeBSD use gmake

### DIFF
--- a/backtrace-sys/build.rs
+++ b/backtrace-sys/build.rs
@@ -61,6 +61,14 @@ fn main() {
         return
     }
 
+    let mut make = "make";
+
+    //FreeBSD make is BSD make
+    if target.contains("freebsd") {
+        make = "gmake"
+    }
+
+
     let cfg = gcc::Config::new();
     let compiler = cfg.get_compiler();
     let cc = compiler.path().file_name().unwrap().to_str().unwrap();
@@ -84,7 +92,7 @@ fn main() {
                 .arg(format!("--host={}", target))
                 .arg(format!("--build={}", host)),
         "sh");
-    run(Command::new("make")
+    run(Command::new(make)
                 .current_dir(&dst)
                 .arg(format!("INCDIR={}",
                              src.join("src/libbacktrace").display())),


### PR DESCRIPTION
currently I can't build backtrace-rs on FreeBSD.
using gmake backtrace-rs can be built on FreeBSD.

I am not a direct consumer of backtrace but via error-chain crate, but I tried your simple example from readme and it seems to be working.
One of tests is failing but i did't have a close look into why.


