### PR TITLE
use GNU-make on BSDs

### DIFF
--- a/backtrace-sys/build.rs
+++ b/backtrace-sys/build.rs
@@ -63,8 +63,11 @@ fn main() {
 
     let mut make = "make";
 
-    //FreeBSD make is BSD make
-    if target.contains("freebsd") {
+    // host BSDs has GNU-make as gmake
+    if host.contains("bitrig") || host.contains("dragonfly") ||
+        host.contains("freebsd") || host.contains("netbsd") ||
+        host.contains("openbsd") {
+            
         make = "gmake"
     }
 


### PR DESCRIPTION
"make" is BSD make on all BSDs. Use "gmake" if the host (and not the target) is a BSD.

this commit would be required to build nightly rustc on BSD.