### PR TITLE
Don't read past the Name buffer if the symbol name exceeds the max length

### DIFF
--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -70,8 +70,15 @@ pub fn resolve(addr: *mut c_void, cb: &mut FnMut(&super::Symbol)) {
         if ret != TRUE {
             return
         }
+
+        // If the symbol name is greater than MaxNameLen, SymFromAddrW will
+        // give a buffer of (MaxNameLen - 1) characters and set NameLen to
+        // the real value.
+        let name_len = ::std::cmp::min(info.NameLen as usize,
+                                       info.MaxNameLen as usize - 1);
+
         let name = slice::from_raw_parts(info.Name.as_ptr() as *const u16,
-                                         info.NameLen as usize);
+                                         name_len);
         let name = OsString::from_wide(name);
 
         let mut line = mem::zeroed::<IMAGEHLP_LINEW64>();

--- a/tests/long_fn_name.rs
+++ b/tests/long_fn_name.rs
@@ -1,0 +1,56 @@
+extern crate backtrace;
+
+#[cfg(all(windows, feature = "dbghelp"))]
+extern crate winapi;
+
+use backtrace::Backtrace;
+
+// 50-character module name
+mod _234567890_234567890_234567890_234567890_234567890 {
+    // 50-character struct name
+    #[allow(non_camel_case_types)]
+    pub struct _234567890_234567890_234567890_234567890_234567890<T>(T);
+    impl<T> _234567890_234567890_234567890_234567890_234567890<T> {
+        #[allow(dead_code)]
+        pub fn new() -> ::Backtrace {
+            ::Backtrace::new()
+        }
+    }
+}
+
+// Long function names must be truncated to (MAX_SYM_NAME - 1) characters.
+// Only run this test for msvc, since gnu prints "<no info>" for all frames.
+#[test]
+#[cfg(all(windows, feature = "dbghelp", target_env = "msvc"))]
+fn test_long_fn_name() {
+    use _234567890_234567890_234567890_234567890_234567890::
+        _234567890_234567890_234567890_234567890_234567890 as S;
+
+    // 10 repetitions of struct name, so fully qualified function name is
+    // atleast 10 * (50 + 50) * 2 = 2000 characters long.
+    // It's actually longer since it also includes `::`, `<>` and the
+    // name of the current module
+    let bt = S::<S<S<S<S<S<S<S<S<S<i32>>>>>>>>>>::new();
+    println!("{:?}", bt);
+
+    let mut found_long_name_frame = false;
+
+    for frame in bt.frames() {
+        let symbols = frame.symbols();
+        if symbols.is_empty() {
+            continue;
+        }
+
+        if let Some(function_name) = symbols[0].name() {
+            let function_name = function_name.as_str().unwrap();
+            if function_name.contains(
+                "::_234567890_234567890_234567890_234567890_234567890")
+            {
+                found_long_name_frame = true;
+                assert_eq!(function_name.len(), winapi::MAX_SYM_NAME - 1);
+            }
+        }
+    }
+
+    assert!(found_long_name_frame);
+}


### PR DESCRIPTION
SymFromAddrW sets NameLen to the real length of the symbol, which can be
greater than MaxNameLen. Before this change, such a symbol would cause
the code to read past the end of the Name buffer into garbage. With this
change, the code reads only till the min of NameLen and (MaxNameLen - 1).

Fixes #59