### PR TITLE
build: find correct ranlib tool and pass it to configure

### DIFF
--- a/backtrace-sys/build.rs
+++ b/backtrace-sys/build.rs
@@ -98,11 +98,13 @@ fn main() {
         flags.push(flag);
     }
     let ar = find_tool(&compiler, cc, "ar");
+    let ranlib = find_tool(&compiler, cc, "ranlib");
     let mut cmd = Command::new("sh");
 
     cmd.arg(configure)
        .current_dir(&dst)
        .env("AR", &ar)
+       .env("RANLIB", &ranlib)
        .env("CC", compiler.path())
        .env("CFLAGS", flags)
        .arg("--with-pic")


### PR DESCRIPTION
Adds `ranlib` to the list of environment variables passed to configure when building the C library. This allows the toolchain to be configured like the other required binutils.

fixes #68 