### PR TITLE
Don't use libbacktrace on fuchsia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ dbghelp-sys = { version = "0.2", optional = true }
 kernel32-sys = { version = "0.2", optional = true }
 winapi = { version = "0.2.5", optional = true }
 
-[target.'cfg(all(unix, not(target_os = "emscripten"), not(target_os = "macos"), not(target_os = "ios")))'.dependencies]
+[target.'cfg(all(unix, not(target_os = "fuchsia"), not(target_os = "emscripten"), not(target_os = "macos"), not(target_os = "ios")))'.dependencies]
 backtrace-sys = { path = "backtrace-sys", version = "0.1.3", optional = true }
 
 # Each feature controls the two phases of finding a backtrace: getting a

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -263,6 +263,7 @@ cfg_if! {
         use self::gimli::Symbol as SymbolImp;
     } else if #[cfg(all(feature = "libbacktrace",
                         unix,
+                        not(target_os = "fuchsia"),
                         not(target_os = "emscripten"),
                         not(target_os = "macos"),
                         not(target_os = "ios")))] {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -6,10 +6,11 @@ use std::thread;
 static LIBUNWIND: bool = cfg!(all(unix, feature = "libunwind"));
 static UNIX_BACKTRACE: bool = cfg!(all(unix, feature = "unix-backtrace"));
 static LIBBACKTRACE: bool = cfg!(all(unix, feature = "libbacktrace")) &&
-                            !cfg!(target_os = "macos") && !cfg!(target_os = "ios");
+                            !cfg!(target_os = "fuchsia") && !cfg!(target_os = "macos") &&
+                            !cfg!(target_os = "ios");
 static CORESYMBOLICATION: bool = cfg!(all(any(target_os = "macos", target_os = "ios"),
                                           feature = "coresymbolication"));
-static DLADDR: bool = cfg!(all(unix, feature = "dladdr"));
+static DLADDR: bool = cfg!(all(unix, feature = "dladdr")) && !cfg!(target_os = "fuchsia");
 static DBGHELP: bool = cfg!(all(windows, feature = "dbghelp"));
 static MSVC: bool = cfg!(target_env = "msvc");
 static GIMLI_SYMBOLIZE: bool = cfg!(all(feature = "gimli-symbolize",


### PR DESCRIPTION
This unblocks us from using backtrace-rs on Fuchsia while we sort out how to get backtraces.