### PR TITLE
migrate to winapi 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,7 @@ findshlibs = { version = "0.3.3", optional = true }
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-dbghelp-sys = { version = "0.2", optional = true }
-kernel32-sys = { version = "0.2", optional = true }
-winapi = { version = "0.2.5", optional = true }
+winapi = { version = "0.3", optional = true, features = ["std", "dbghelp", "processthreadsapi", "winnt", "minwindef"] }
 
 [target.'cfg(all(unix, not(target_os = "fuchsia"), not(target_os = "emscripten"), not(target_os = "macos"), not(target_os = "ios")))'.dependencies]
 backtrace-sys = { path = "backtrace-sys", version = "0.1.3", optional = true }
@@ -63,7 +61,7 @@ default = ["libunwind", "libbacktrace", "coresymbolication", "dladdr", "dbghelp"
     #   function to acquire a backtrace
     libunwind = []
     unix-backtrace = []
-    dbghelp = ["kernel32-sys", "winapi", "dbghelp-sys"]
+    dbghelp = ["winapi"]
     kernel32 = []
 
     #=======================================
@@ -96,3 +94,6 @@ default = ["libunwind", "libbacktrace", "coresymbolication", "dladdr", "dbghelp"
     # Various features used for enabling rustc-serialize or syntex codegen.
     serialize-rustc = ["rustc-serialize"]
     serialize-serde = ["serde", "serde_derive"]
+
+[replace]
+"winapi:0.3.2" = { git = "https://github.com/steffengy/winapi-rs", branch = "0.3" }

--- a/src/backtrace/dbghelp.rs
+++ b/src/backtrace/dbghelp.rs
@@ -11,8 +11,12 @@
 #![allow(bad_style)]
 
 use std::mem;
-use winapi::*;
-use kernel32;
+use winapi::ctypes::*;
+use winapi::shared::minwindef::*;
+use winapi::um::processthreadsapi;
+use winapi::um::winnt::{self, CONTEXT};
+use winapi::um::dbghelp;
+use winapi::um::dbghelp::*;
 
 pub struct Frame {
     inner: STACKFRAME64,
@@ -36,15 +40,15 @@ pub fn trace(cb: &mut FnMut(&super::Frame) -> bool) {
 
     unsafe {
         // Allocate necessary structures for doing the stack walk
-        let process = kernel32::GetCurrentProcess();
-        let thread = kernel32::GetCurrentThread();
+        let process = processthreadsapi::GetCurrentProcess();
+        let thread = processthreadsapi::GetCurrentThread();
 
         // The CONTEXT structure needs to be aligned on a 16-byte boundary for
         // 64-bit Windows, but currently we don't have a way to express that in
         // Rust. Allocations are generally aligned to 16-bytes, though, so we
         // box this up.
         let mut context = Box::new(mem::zeroed::<CONTEXT>());
-        kernel32::RtlCaptureContext(&mut *context);
+        winnt::RtlCaptureContext(&mut *context);
         let mut frame = super::Frame {
             inner: Frame { inner: mem::zeroed() },
         };
@@ -54,15 +58,15 @@ pub fn trace(cb: &mut FnMut(&super::Frame) -> bool) {
         let _c = ::dbghelp_init();
 
         // And now that we're done with all the setup, do the stack walking!
-        while ::dbghelp::StackWalk64(image as DWORD,
-                                     process,
-                                     thread,
-                                     &mut frame.inner.inner,
-                                     &mut *context as *mut _ as *mut _,
-                                     None,
-                                     Some(::dbghelp::SymFunctionTableAccess64),
-                                     Some(::dbghelp::SymGetModuleBase64),
-                                     None) == TRUE {
+        while dbghelp::StackWalk64(image as DWORD,
+                                   process,
+                                   thread,
+                                   &mut frame.inner.inner,
+                                   &mut *context as *mut _ as *mut _,
+                                   None,
+                                   Some(dbghelp::SymFunctionTableAccess64),
+                                   Some(dbghelp::SymGetModuleBase64),
+                                   None) == TRUE {
             if frame.inner.inner.AddrPC.Offset == frame.inner.inner.AddrReturn.Offset ||
                frame.inner.inner.AddrPC.Offset == 0 ||
                frame.inner.inner.AddrReturn.Offset == 0 {
@@ -84,7 +88,7 @@ fn init_frame(frame: &mut STACKFRAME64, ctx: &CONTEXT) -> WORD {
     frame.AddrStack.Mode = AddrModeFlat;
     frame.AddrFrame.Offset = ctx.Rbp as u64;
     frame.AddrFrame.Mode = AddrModeFlat;
-    IMAGE_FILE_MACHINE_AMD64
+    winnt::IMAGE_FILE_MACHINE_AMD64
 }
 
 #[cfg(target_arch = "x86")]
@@ -95,5 +99,5 @@ fn init_frame(frame: &mut STACKFRAME64, ctx: &CONTEXT) -> WORD {
     frame.AddrStack.Mode = AddrModeFlat;
     frame.AddrFrame.Offset = ctx.Ebp as u64;
     frame.AddrFrame.Mode = AddrModeFlat;
-    IMAGE_FILE_MACHINE_I386
+    winnt::IMAGE_FILE_MACHINE_I386
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,7 @@
 
 #[cfg(unix)]
 extern crate libc;
-#[cfg(all(windows, feature = "kernel32-sys"))] extern crate kernel32;
 #[cfg(all(windows, feature = "winapi"))] extern crate winapi;
-#[cfg(all(windows, feature = "dbghelp"))] extern crate dbghelp;
 
 #[cfg(feature = "serde_derive")]
 #[cfg_attr(feature = "serde_derive", macro_use)]
@@ -165,12 +163,15 @@ mod lock {
 // requires external synchronization
 #[cfg(all(windows, feature = "dbghelp"))]
 unsafe fn dbghelp_init() {
+    use winapi::shared::minwindef;
+    use winapi::um::{dbghelp, processthreadsapi};
+
     static mut INITIALIZED: bool = false;
 
     if !INITIALIZED {
-        dbghelp::SymInitializeW(kernel32::GetCurrentProcess(),
+        dbghelp::SymInitializeW(processthreadsapi::GetCurrentProcess(),
                                 0 as *mut _,
-                                winapi::TRUE);
+                                minwindef::TRUE);
         INITIALIZED = true;
     }
 }

--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -15,8 +15,12 @@ use std::mem;
 use std::path::Path;
 use std::os::windows::prelude::*;
 use std::slice;
-use kernel32;
-use winapi::*;
+use winapi::ctypes::*;
+use winapi::shared::basetsd::*;
+use winapi::shared::minwindef::*;
+use winapi::um::processthreadsapi;
+use winapi::um::dbghelp;
+use winapi::um::dbghelp::*;
 
 use SymbolName;
 
@@ -63,7 +67,7 @@ pub fn resolve(addr: *mut c_void, cb: &mut FnMut(&super::Symbol)) {
         let _c = ::dbghelp_init();
 
         let mut displacement = 0u64;
-        let ret = ::dbghelp::SymFromAddrW(kernel32::GetCurrentProcess(),
+        let ret = dbghelp::SymFromAddrW(processthreadsapi::GetCurrentProcess(),
                                           addr as DWORD64,
                                           &mut displacement,
                                           info);
@@ -84,7 +88,7 @@ pub fn resolve(addr: *mut c_void, cb: &mut FnMut(&super::Symbol)) {
         let mut line = mem::zeroed::<IMAGEHLP_LINEW64>();
         line.SizeOfStruct = mem::size_of::<IMAGEHLP_LINEW64>() as DWORD;
         let mut displacement = 0;
-        let ret = ::dbghelp::SymGetLineFromAddrW64(kernel32::GetCurrentProcess(),
+        let ret = dbghelp::SymGetLineFromAddrW64(processthreadsapi::GetCurrentProcess(),
                                                    addr as DWORD64,
                                                    &mut displacement,
                                                    &mut line);

--- a/tests/long_fn_name.rs
+++ b/tests/long_fn_name.rs
@@ -23,6 +23,7 @@ mod _234567890_234567890_234567890_234567890_234567890 {
 #[test]
 #[cfg(all(windows, feature = "dbghelp", target_env = "msvc"))]
 fn test_long_fn_name() {
+    use winapi::um::dbghelp;
     use _234567890_234567890_234567890_234567890_234567890::
         _234567890_234567890_234567890_234567890_234567890 as S;
 
@@ -47,7 +48,7 @@ fn test_long_fn_name() {
                 "::_234567890_234567890_234567890_234567890_234567890")
             {
                 found_long_name_frame = true;
-                assert_eq!(function_name.len(), winapi::MAX_SYM_NAME - 1);
+                assert_eq!(function_name.len(), dbghelp::MAX_SYM_NAME - 1);
             }
         }
     }


### PR DESCRIPTION
This should be ready to land as is once CI passes and after another winapi release....

Also the kernel32 feature seems to be unused?