### PR TITLE
Update gimli symbolizer to return inlined functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,6 @@ findshlibs = { version = "0.3.3", optional = true }
 gimli = { version = "0.15.0", optional = true }
 memmap = { version = "0.6.2", optional = true }
 object = { version = "0.7.0", optional = true }
-rental = { version = "0.4.16", optional = true }
-stable_deref_trait = { version = "1.0.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -91,7 +89,7 @@ default = ["libunwind", "libbacktrace", "coresymbolication", "dladdr", "dbghelp"
     libbacktrace = ["backtrace-sys"]
     dladdr = []
     coresymbolication = []
-    gimli-symbolize = ["addr2line", "findshlibs", "gimli", "memmap", "object", "rental", "stable_deref_trait" ]
+    gimli-symbolize = ["addr2line", "findshlibs", "gimli", "memmap", "object" ]
 
     #=======================================
     # Methods of serialization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,13 @@ rustc-serialize = { version = "0.3", optional = true }
 # Optionally demangle C++ frames' symbols in backtraces.
 cpp_demangle = { default-features = false, version = "0.2.3", optional = true }
 
-addr2line = { version = "0.5.0", optional = true }
+addr2line = { version = "0.6.0", optional = true }
 findshlibs = { version = "0.3.3", optional = true }
+gimli = { version = "0.15.0", optional = true }
+memmap = { version = "0.6.2", optional = true }
+object = { version = "0.7.0", optional = true }
+rental = { version = "0.4.16", optional = true }
+stable_deref_trait = { version = "1.0.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -86,7 +91,7 @@ default = ["libunwind", "libbacktrace", "coresymbolication", "dladdr", "dbghelp"
     libbacktrace = ["backtrace-sys"]
     dladdr = []
     coresymbolication = []
-    gimli-symbolize = ["addr2line", "findshlibs"]
+    gimli-symbolize = ["addr2line", "findshlibs", "gimli", "memmap", "object", "rental", "stable_deref_trait" ]
 
     #=======================================
     # Methods of serialization

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,35 +88,15 @@ extern crate rustc_demangle;
 #[cfg(feature = "cpp_demangle")]
 extern crate cpp_demangle;
 
-#[cfg(all(feature = "gimli-symbolize",
-          unix,
-          target_os = "linux"))]
-extern crate addr2line;
-#[cfg(all(feature = "gimli-symbolize",
-          unix,
-          target_os = "linux"))]
-extern crate findshlibs;
-#[cfg(all(feature = "gimli-symbolize",
-          unix,
-          target_os = "linux"))]
-extern crate gimli;
-#[cfg(all(feature = "gimli-symbolize",
-          unix,
-          target_os = "linux"))]
-extern crate memmap;
-#[cfg(all(feature = "gimli-symbolize",
-          unix,
-          target_os = "linux"))]
-extern crate object;
-#[cfg(all(feature = "gimli-symbolize",
-          unix,
-          target_os = "linux"))]
-#[macro_use]
-extern crate rental;
-#[cfg(all(feature = "gimli-symbolize",
-          unix,
-          target_os = "linux"))]
-extern crate stable_deref_trait;
+cfg_if! {
+    if #[cfg(all(feature = "gimli-symbolize", unix, target_os = "linux"))] {
+        extern crate addr2line;
+        extern crate findshlibs;
+        extern crate gimli;
+        extern crate memmap;
+        extern crate object;
+    }
+}
 
 #[allow(dead_code)] // not used everywhere
 #[cfg(unix)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,27 @@ extern crate addr2line;
           unix,
           target_os = "linux"))]
 extern crate findshlibs;
+#[cfg(all(feature = "gimli-symbolize",
+          unix,
+          target_os = "linux"))]
+extern crate gimli;
+#[cfg(all(feature = "gimli-symbolize",
+          unix,
+          target_os = "linux"))]
+extern crate memmap;
+#[cfg(all(feature = "gimli-symbolize",
+          unix,
+          target_os = "linux"))]
+extern crate object;
+#[cfg(all(feature = "gimli-symbolize",
+          unix,
+          target_os = "linux"))]
+#[macro_use]
+extern crate rental;
+#[cfg(all(feature = "gimli-symbolize",
+          unix,
+          target_os = "linux"))]
+extern crate stable_deref_trait;
 
 #[allow(dead_code)] // not used everywhere
 #[cfg(unix)]


### PR DESCRIPTION
The addr2line crate can now return inlined functions. It also requires us to load the file ourselves now.

There doesn't appear to be any tests for inlined functions. I hacked the smoke test to try it out, but haven't included that in this PR since I wasn't sure how well other symbolizers would handle that.

cc @fitzgen 