### PR TITLE
Fix a potential infinite loop in the build.rs tool

### DIFF
--- a/backtrace-sys/build.rs
+++ b/backtrace-sys/build.rs
@@ -148,14 +148,16 @@ fn main() {
     let mut objs = Vec::new();
     let objcopy = find_tool(&compiler, cc, "objcopy");
     for obj in t!(tmpdir.read_dir()) {
-        let obj = t!(obj);
-        run(Command::new(&objcopy)
-                    .arg("--redefine-syms=symbol-map")
-                    .arg(obj.path()),
-            objcopy.to_str().unwrap());
-        objs.push(obj.path());
+        objs.push(t!(obj).path());
     }
-
+    
+	for obj in objs.as_slice() {
+        run(Command::new(&objcopy)
+                .arg("--redefine-syms=symbol-map")
+                .arg(obj),
+        objcopy.to_str().unwrap());
+    }
+    
     run(Command::new(&ar).arg("crus").arg(&lib).args(&objs),
         ar.to_str().unwrap());
 }


### PR DESCRIPTION
In the current iteration, the script invokes objcopy on the object files that
are in a temporary directory. The directory is read using read_dir, which on
unix systems uses the opendir() call. The objcopy is actually invoked during
the loop that reads the files in the directory. According tot SUSv3 spec, what
happens when during the opendir() and readdir() cycle files are added or
removed from the directory is undefined. During the objcopy invocation the
existing file is unlinked and a new one is created.

On Haiku's native file system, the iterator is updated when entries are added
or removed from a directory. In this case the actual behavior was that the
iterator keeps pointing at the newly created file, which makes the script
stay stuck forever on this particular file.

This change takes the actual processing of the files with objcopy out of the
loop that reads the directory entries, thus preventing such a loop.