### PR TITLE
Find libunwind include path using pkg-config, fixes #102

### DIFF
--- a/backtrace-sys/Cargo.toml
+++ b/backtrace-sys/Cargo.toml
@@ -16,3 +16,4 @@ libc = "0.2"
 
 [build-dependencies]
 cc = "1.0"
+pkg-config = "0.3"

--- a/backtrace-sys/build.rs
+++ b/backtrace-sys/build.rs
@@ -1,3 +1,4 @@
+extern crate pkg_config;
 extern crate cc;
 
 use std::env;
@@ -45,6 +46,12 @@ fn main() {
             build.define("BACKTRACE_ELF_SIZE", "64");
         } else {
             build.define("BACKTRACE_ELF_SIZE", "32");
+        }
+    }
+
+    if let Ok(unwind) = pkg_config::Config::new().probe("libunwind") {
+        for path in unwind.include_paths {
+            build.include(path);
         }
     }
 


### PR DESCRIPTION
Keeping optional (`if let Ok`) because it's not required on other platforms...

Also this should check for the `libunwind` feature? But I couldn't get that to work, `cfg!(feature = "libunwind")` was always false in build.rs...