### PR TITLE
fix demangling on macOS

### DIFF
--- a/src/symbolize/coresymbolication.rs
+++ b/src/symbolize/coresymbolication.rs
@@ -119,7 +119,7 @@ dlsym! {
         fn CSSourceInfoGetLineNumber(info: CSTypeRef) -> c_int;
         fn CSSourceInfoGetPath(info: CSTypeRef) -> *const c_char;
         fn CSSourceInfoGetSymbol(info: CSTypeRef) -> CSTypeRef;
-        fn CSSymbolGetName(sym: CSTypeRef) -> *const c_char;
+        fn CSSymbolGetMangledName(sym: CSTypeRef) -> *const c_char;
         fn CSSymbolGetSymbolOwner(sym: CSTypeRef) -> CSTypeRef;
         fn CSSymbolOwnerGetBaseAddress(symowner: CSTypeRef) -> *mut c_void;
     }
@@ -165,7 +165,7 @@ unsafe fn try_resolve(addr: *mut c_void, cb: &mut FnMut(&super::Symbol)) -> bool
                     } else {
                         0
                     },
-                    name: get(&CSSymbolGetName)(sym),
+                    name: get(&CSSymbolGetMangledName)(sym),
                     addr: get(&CSSymbolOwnerGetBaseAddress)(owner),
                 },
             });


### PR DESCRIPTION
Hello,

On macOS backtrace-rs is retrieving symbol names using `CSSymbolGetName` from CoreSymbolication. `CSSymbolGetName` returns partially demangled names which cannot be fully demangled by rustc-demangle. For example `std::rt::lang_start::_$u7b$$u7b$closure$u7d$$u7d$::h0035fc3498340fdf`.

Instead call `CSSymbolGetMangledName` which returns the raw mangled name suitable for demangling by rustc-demangle.

| Function               | Result                                                                    |
|------------------------|---------------------------------------------------------------------------|
| CSSymbolGetName        | std::rt::lang_start::_$u7b$$u7b$closure$u7d$$u7d$::h0035fc3498340fdf      |
| CSSymbolGetMangledName | __ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h0035fc3498340fdfE |

After this change the symbol name returned by backtrace-rs is `std::rt::lang_start::{{closure}}::h0035fc3498340fdf`.

