### PR TITLE
Added mgwhelp support (Dr. MinGW)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ backtrace-sys = { path = "backtrace-sys", version = "0.1.17", optional = true }
 # Note that not all features are available on all platforms, so even though a
 # feature is enabled some other feature may be used instead.
 [features]
-default = ["libunwind", "libbacktrace", "coresymbolication", "dladdr", "dbghelp"]
+default = ["libunwind", "libbacktrace", "coresymbolication", "dladdr", "dbghelp", "mgwhelp"]
 
 #=======================================
 # Methods of acquiring a backtrace
@@ -86,10 +86,12 @@ kernel32 = []
 #   the moment, this is only possible when targetting Linux, since macOS
 #   splits DWARF out into a separate object file. Enabling this feature
 #   means one less C dependency.
+# - mgwhelp: on windows this enables using Dr. MinGW to find symbol names.
 libbacktrace = ["backtrace-sys"]
 dladdr = []
 coresymbolication = []
 gimli-symbolize = ["addr2line", "findshlibs", "gimli", "memmap", "object" ]
+mgwhelp = []
 
 #=======================================
 # Methods of serialization


### PR DESCRIPTION
Should fix https://github.com/alexcrichton/backtrace-rs/issues/66.

Currently its not working as gcc can't find `-lmgwhelp` for some reason even though I installed Dr. MinGW. Posted here anyway to see if I could get some help with it as this is the first time I have used Rust FFI.

Update: I'm able to find mgwhelp with gcc on its own, trying to find a way to pass `-Wl,--verbose` to gcc through rustc or cargo to get a better idea of whats going on.