### PR TITLE
backtrace-sys: Use target_pointer_width for BACKTRACE_ELF_SIZE

### DIFF
--- a/backtrace-sys/build.rs
+++ b/backtrace-sys/build.rs
@@ -40,7 +40,8 @@ fn main() {
         build.flag("-fvisibility=hidden");
         build.file("src/libbacktrace/elf.c");
 
-        if target.contains("64") {
+        let pointer_width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
+        if pointer_width == "64" {
             build.define("BACKTRACE_ELF_SIZE", "64");
         } else {
             build.define("BACKTRACE_ELF_SIZE", "32");


### PR DESCRIPTION
The former code used `target.contains("64")` to detect Elf64 targets,
but this is inaccurate in a few cases:

- `s390x-unknown-linux-gnu` is 64-bit
- `sparcv9-sun-solaris` is 64-bit
- `x86_64-unknown-linux-gnux32` is 32-bit

Instead the build script can use `CARGO_CFG_TARGET_POINTER_WIDTH` to
reliably detect 64-bit targets.