### PR TITLE
Print backtraces more like libstd does

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -10,6 +10,9 @@ use types::c_void;
 ///
 /// This structure can be used to capture a backtrace at various points in a
 /// program and later used to inspect what the backtrace was at that time.
+///
+/// `Backtrace` supports pretty-printing of backtraces by implementing
+/// `Display` and `Debug` (which do the same thing).
 #[derive(Clone)]
 #[cfg_attr(feature = "serialize-rustc", derive(RustcDecodable, RustcEncodable))]
 #[cfg_attr(feature = "serialize-serde", derive(Deserialize, Serialize))]
@@ -261,6 +264,12 @@ impl fmt::Debug for Backtrace {
         }
 
         Ok(())
+    }
+}
+
+impl fmt::Display for Backtrace {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, fmt)
     }
 }
 

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -233,32 +233,37 @@ impl fmt::Debug for Backtrace {
 
         for (idx, frame) in iter.enumerate() {
             let ip = frame.ip();
-            write!(fmt, "\n{:4}: {:2$?}", idx, ip, hex_width)?;
+            write!(fmt, "\n{:4}: ", idx)?;
 
             let symbols = match frame.symbols {
                 Some(ref s) => s,
                 None => {
-                    write!(fmt, " - <unresolved>")?;
+                    write!(fmt, "<unresolved> ({:?})", ip)?;
                     continue
                 }
             };
             if symbols.len() == 0 {
-                write!(fmt, " - <no info>")?;
+                write!(fmt, "<no info> ({:?})", ip)?;
+                continue;
             }
 
             for (idx, symbol) in symbols.iter().enumerate() {
                 if idx != 0 {
-                    write!(fmt, "\n      {:1$}", "", hex_width)?;
+                    write!(fmt, "\n      ")?;
                 }
 
                 if let Some(name) = symbol.name() {
-                    write!(fmt, " - {}", name)?;
+                    write!(fmt, "{}", name)?;
                 } else {
-                    write!(fmt, " - <unknown>")?;
+                    write!(fmt, "<unknown>")?;
+                }
+
+                if idx == 0 {
+                    write!(fmt, " ({:?})", ip)?;
                 }
 
                 if let (Some(file), Some(line)) = (symbol.filename(), symbol.lineno()) {
-                    write!(fmt, "\n      {:3$}at {}:{}", "", file.display(), line, hex_width)?;
+                    write!(fmt, "\n             at {}:{}", file.display(), line)?;
                 }
             }
         }


### PR DESCRIPTION
Also, add a `impl Display` that does the same as the `impl Debug`, and point out in the `Backtrace` docs that this supports pretty-printing.

Before:
```
   0:     0x562ebc7d253f - smoke::smoke_test_frames::frame_4::h3002adeca5ef512d
                        at tests/smoke.rs:58
   1:     0x562ebc7d203d - smoke::smoke_test_frames::frame_3::h1cc43348d795f729
                        at tests/smoke.rs:27
   2:     0x562ebc7d202d - smoke::smoke_test_frames::frame_2::hf7d0fb1657e7471b
                        at tests/smoke.rs:26
   3:     0x562ebc7d201d - smoke::smoke_test_frames::frame_1::hf30df21f52f6d198
                        at tests/smoke.rs:25
   4:     0x562ebc7d200a - smoke::smoke_test_frames::hd79448d2447fa396
                        at tests/smoke.rs:24
   5:     0x562ebc7da8d9 - smoke::smoke_test_frames::{{closure}}::h1b1167e60b561246
                        at tests/smoke.rs:23
   6:     0x562ebc7d797d - core::ops::function::FnOnce::call_once::hdc37421aa933feab
                        at libcore/ops/function.rs:238
   7:     0x562ebc7e046e - test::run_test::{{closure}}::hdf0a2aea24e9bc7b
                        at libtest/lib.rs:1468
                         - core::ops::function::FnOnce::call_once::h8c5514eb367f35a4
                        at libcore/ops/function.rs:238
                         - <F as alloc::boxed::FnBox<A>>::call_box::h3d8a1810f3c5b40f
                        at liballoc/boxed.rs:672
   8:     0x562ebc86aa89 - __rust_maybe_catch_panic
                        at libpanic_unwind/lib.rs:102
   9:     0x562ebc8021b2 - std::panicking::try::h622948ba1e648820
                        at libstd/panicking.rs:289
                         - std::panic::catch_unwind::h2c76e12f7818731b
                        at libstd/panic.rs:392
                         - test::run_test::run_test_inner::{{closure}}::h48b9334c94e4c528
                        at libtest/lib.rs:1423
                         - std::sys_common::backtrace::__rust_begin_short_backtrace::h1cacee00af43ed73
                        at libstd/sys_common/backtrace.rs:136
  10:     0x562ebc802c54 - std::thread::Builder::spawn::{{closure}}::{{closure}}::h2b9441de390857f0
                        at libstd/thread/mod.rs:409
                         - <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h14e54e616e164da6
                        at libstd/panic.rs:313
                         - std::panicking::try::do_call::h41920762ece46401
                        at libstd/panicking.rs:310
```

After:
```
   0: smoke::smoke_test_frames::frame_4::h3002adeca5ef512d (0x55f7452f953f)
             at tests/smoke.rs:58
   1: smoke::smoke_test_frames::frame_3::h1cc43348d795f729 (0x55f7452f903d)
             at tests/smoke.rs:27
   2: smoke::smoke_test_frames::frame_2::hf7d0fb1657e7471b (0x55f7452f902d)
             at tests/smoke.rs:26
   3: smoke::smoke_test_frames::frame_1::hf30df21f52f6d198 (0x55f7452f901d)
             at tests/smoke.rs:25
   4: smoke::smoke_test_frames::hd79448d2447fa396 (0x55f7452f900a)
             at tests/smoke.rs:24
   5: smoke::smoke_test_frames::{{closure}}::h1b1167e60b561246 (0x55f7453018d9)
             at tests/smoke.rs:23
   6: core::ops::function::FnOnce::call_once::hdc37421aa933feab (0x55f7452fe97d)
             at libcore/ops/function.rs:238
   7: test::run_test::{{closure}}::hdf0a2aea24e9bc7b (0x55f74530746e)
             at libtest/lib.rs:1468
      core::ops::function::FnOnce::call_once::h8c5514eb367f35a4
             at libcore/ops/function.rs:238
      <F as alloc::boxed::FnBox<A>>::call_box::h3d8a1810f3c5b40f
             at liballoc/boxed.rs:672
   8: __rust_maybe_catch_panic (0x55f745391a89)
             at libpanic_unwind/lib.rs:102
   9: std::panicking::try::h622948ba1e648820 (0x55f7453291b2)
             at libstd/panicking.rs:289
      std::panic::catch_unwind::h2c76e12f7818731b
             at libstd/panic.rs:392
      test::run_test::run_test_inner::{{closure}}::h48b9334c94e4c528
             at libtest/lib.rs:1423
      std::sys_common::backtrace::__rust_begin_short_backtrace::h1cacee00af43ed73
             at libstd/sys_common/backtrace.rs:136
  10: std::thread::Builder::spawn::{{closure}}::{{closure}}::h2b9441de390857f0 (0x55f745329c54)
             at libstd/thread/mod.rs:409
      <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h14e54e616e164da6
             at libstd/panic.rs:313
      std::panicking::try::do_call::h41920762ece46401
             at libstd/panicking.rs:310
```
I find this more readable because it doesn't indent everything so far to the right, and it de-emphasizes the hard-to-interpret IP (but the IP is still printed in the first line for each frame).

For comparison, a `RUST_BACKTRACE=1` output:
```
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at src/libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:71
   2: std::panicking::default_hook::{{closure}}
             at src/libstd/sys_common/backtrace.rs:59
             at src/libstd/panicking.rs:210
   3: std::panicking::default_hook
             at src/libstd/panicking.rs:224
   4: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:487
   5: std::panicking::continue_panic_fmt
             at src/libstd/panicking.rs:394
   6: std::panicking::begin_panic_fmt
             at src/libstd/panicking.rs:349
   7: panic::main
   8: std::rt::lang_start::{{closure}}
   9: std::panicking::try::do_call
             at src/libstd/rt.rs:59
             at src/libstd/panicking.rs:306
  10: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:102
  11: std::rt::lang_start_internal
             at src/libstd/panicking.rs:285
             at src/libstd/panic.rs:398
             at src/libstd/rt.rs:58
```