### PR TITLE
Error on Mac while building the docker image

### DIFF
--- a/src/symbolize/libbacktrace.rs
+++ b/src/symbolize/libbacktrace.rs
@@ -16,7 +16,8 @@ use std::ffi::CStr;
 use std::{ptr, slice};
 use std::sync::{ONCE_INIT, Once};
 
-use libc::{self, c_char, c_int, c_void, uintptr_t};
+use libc::{self, c_char, c_int, uintptr_t};
+use types::c_void;
 
 use SymbolName;
 


### PR DESCRIPTION
Expected enum `std::os::raw::c_void`, found enum `libc::c_void` in libbacktrace.rs:156
Expected enum `std::os::raw::c_void`, found enum `libc::c_void` in libbacktrace.rs:172
Expected enum `std::os::raw::c_void`, found enum `libc::c_void` in libbacktrace.rs:176
