### PR TITLE
Supporting Backtrace crate for x86_64-fortanix-unknown-sgx.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ gimli = { version = "0.16.0", optional = true }
 memmap = { version = "0.7.0", optional = true }
 object = { version = "0.9.0", optional = true }
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(any(unix, target_env = "sgx"))'.dependencies]
 libc = { version = "0.2.45", default-features = false }
 
 [target.'cfg(windows)'.dependencies]

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -104,10 +104,11 @@ impl fmt::Debug for Frame {
 }
 
 cfg_if! {
-    if #[cfg(all(unix,
+    if #[cfg(any(all(unix,
                  not(target_os = "emscripten"),
                  not(all(target_os = "ios", target_arch = "arm")),
-                 feature = "libunwind"))] {
+                 feature = "libunwind"),
+                 target_env="sgx"))] {
         mod libunwind;
         use self::libunwind::trace as trace_imp;
         use self::libunwind::Frame as FrameImp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,11 +71,12 @@
 #![doc(html_root_url = "https://docs.rs/backtrace")]
 #![deny(missing_docs)]
 #![no_std]
+#![cfg_attr(target_env = "sgx", feature(sgx_platform))]
 
 #[cfg(feature = "std")]
 #[macro_use] extern crate std;
 
-#[cfg(unix)]
+#[cfg(any(unix, target_env = "sgx"))]
 extern crate libc;
 #[cfg(windows)]
 extern crate winapi;


### PR DESCRIPTION
Supporting a new target for this crate needs us to support backtrace and symbolize.
## backtrace:
This is supported via a port of libunwind which is linked to x86_64-fortanix-unknown-sgx. See [rust-lang/#56979](https://github.com/rust-lang/rust/pull/56979) for more details
## symbolize:
To reduce enclave TCB size, we do not support symbol resolution for this target. So symbol resolution would basically pass via `NOOP` implementation. For generating backtrace after a panic, in the std library, we rather, display the offset of each function, which could be resolved later. See [rust-lang/#57441](https://github.com/rust-lang/rust/pull/57441) for more details.
This PR tries to emulate same behaviour for backtrace crate. Here we let the back trace have actual addresses, which would be consistent with  the function pointers  at run time. But, while displaying the back-trace structure, we convert the addresses to their corresponding offsets so that the user could easily resolve the actual symbols (say, via `addr2len`).

cc: @jethrogb