### PR TITLE
Add support for UWP targets

### DIFF
--- a/backtrace-sys/build.rs
+++ b/backtrace-sys/build.rs
@@ -36,7 +36,7 @@ fn main() {
 
     if target.contains("darwin") {
         build.file("src/libbacktrace/macho.c");
-    } else if target.contains("windows") {
+    } else if target.contains("windows") || target.contains("uwp") {
         build.file("src/libbacktrace/pecoff.c");
     } else {
         build.file("src/libbacktrace/elf.c");


### PR DESCRIPTION
Hi,

This MR is related to https://github.com/rust-lang/rust/pull/60260, and allows the use of "uwp" as part of the target.

I'm unsure what the best way is, when it comes to cross dependent MRs, so I'll gladly change things according to your reviews!

Thanks,