### PR TITLE
Cleanup dbghelp so that stdlib can print backtraces on panic again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ std = []
 #   function to acquire a backtrace
 libunwind = []
 unix-backtrace = []
-dbghelp = []
+dbghelp = ["std"]
 kernel32 = []
 
 #=======================================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ std = []
 libunwind = []
 unix-backtrace = []
 dbghelp = ["std"]
-kernel32 = []
+kernel32 = ["dbghelp"]
 
 #=======================================
 # Methods of resolving symbols

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,14 +65,14 @@ std = []
 # - unix-backtrace: this uses the backtrace(3) function to acquire a
 #   backtrace, but is not as reliable as libunwind. It is, however,
 #   generally found in more locations.
-# - dbghelp: on windows this enables usage of dbghelp.dll to find a
-#   backtrace at runtime
+# - dbghelp: on windows this enables usage of dbghelp.dll to acquire and
+#   resolve a backtrace at runtime
 # - kernel32: on windows this enables using RtlCaptureStackBackTrace as the
 #   function to acquire a backtrace
 libunwind = []
 unix-backtrace = []
-dbghelp = ["std"]
-kernel32 = ["dbghelp"]
+dbghelp = []
+kernel32 = []
 
 #=======================================
 # Methods of resolving symbols

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,0 +1,96 @@
+#![feature(test)]
+
+extern crate test;
+
+extern crate backtrace;
+
+#[cfg(feature = "std")]
+use backtrace::Backtrace;
+
+#[bench]
+#[cfg(feature = "std")]
+fn trace(b: &mut test::Bencher) {
+    #[inline(never)]
+    fn the_function() {
+        backtrace::trace(|frame| {
+            let ip = frame.ip();
+            test::black_box(ip);
+            true
+        });
+    }
+    b.iter(the_function);
+}
+
+#[bench]
+#[cfg(feature = "std")]
+fn trace_and_resolve_callback(b: &mut test::Bencher) {
+    #[inline(never)]
+    fn the_function() {
+        backtrace::trace(|frame| {
+            backtrace::resolve(frame.ip(), |symbol| {
+                let addr = symbol.addr();
+                test::black_box(addr);
+            });
+            true
+        });
+    }
+    b.iter(the_function);
+}
+
+
+
+#[bench]
+#[cfg(feature = "std")]
+fn trace_and_resolve_separate(b: &mut test::Bencher) {
+    #[inline(never)]
+    fn the_function(frames: &mut Vec<*mut std::ffi::c_void>) {
+        backtrace::trace(|frame| {
+            frames.push(frame.ip());
+            true
+        });
+        frames.iter().for_each(|frame_ip| {
+            backtrace::resolve(*frame_ip, |symbol| {
+                test::black_box(symbol);
+            });
+        });
+    }
+    let mut frames = Vec::with_capacity(1024);
+    b.iter(|| {
+        the_function(&mut frames);
+        frames.clear();
+    });
+}
+
+#[bench]
+#[cfg(feature = "std")]
+fn new_unresolved(b: &mut test::Bencher) {
+    #[inline(never)]
+    fn the_function() {
+        let bt = Backtrace::new_unresolved();
+        test::black_box(bt);
+    }
+    b.iter(the_function);
+}
+
+#[bench]
+#[cfg(feature = "std")]
+fn new(b: &mut test::Bencher) {
+    #[inline(never)]
+    fn the_function() {
+        let bt = Backtrace::new();
+        test::black_box(bt);
+    }
+    b.iter(the_function);
+}
+
+#[bench]
+#[cfg(feature = "std")]
+fn new_unresolved_and_resolve_separate(b: &mut test::Bencher) {
+    #[inline(never)]
+    fn the_function() {
+        let mut bt = Backtrace::new_unresolved();
+        bt.resolve();
+        test::black_box(bt);
+    }
+    b.iter(the_function);
+}

--- a/ci/azure-test-all.yml
+++ b/ci/azure-test-all.yml
@@ -37,5 +37,9 @@ steps:
     displayName: "Test backtrace (-default + gimli-symbolize + std)"
   - bash: cargo test --no-default-features --features 'dbghelp std'
     displayName: "Test backtrace (-default + dbghelp + std)"
+  - bash: cargo test --no-default-features --features 'kernel32 std'
+    displayName: "Test backtrace (-default + kernel32 + std)"
+  - bash: cargo test --no-default-features --features 'kernel32 dbghelp std'
+    displayName: "Test backtrace (-default + kernel32 + dbghelp + std)"
   - bash: cd ./cpp_smoke_test && cargo test
     displayName: "Test cpp_smoke_test"

--- a/src/backtrace/dbghelp.rs
+++ b/src/backtrace/dbghelp.rs
@@ -62,7 +62,7 @@ pub unsafe fn trace(cb: &mut FnMut(&super::Frame) -> bool) {
     };
     let image = init_frame(&mut frame.inner.inner, &context.0);
 
-    let cleanup_on_drop = CleanupOnDrop;
+    let _cleanup_on_drop = CleanupOnDrop;
 
     ::TRACE_CLEANUP.with(|trace_cleanup| {
         let mut trace_cleanup = trace_cleanup.borrow_mut();
@@ -120,8 +120,6 @@ pub unsafe fn trace(cb: &mut FnMut(&super::Frame) -> bool) {
                 break
             }
         }
-
-        drop(cleanup_on_drop);
     }
 }
 

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -68,6 +68,10 @@ impl Backtrace {
     /// ```
     #[inline(never)] // want to make sure there's a frame here to remove
     pub fn new() -> Backtrace {
+        // initialize dbghelp only once for both the trace and the resolve
+        #[cfg(all(windows, feature = "dbghelp"))]
+        let _c = unsafe { ::dbghelp_init() };
+
         let mut bt = Self::create(Self::new as usize);
         bt.resolve();
         bt
@@ -141,6 +145,10 @@ impl Backtrace {
     /// If this backtrace has been previously resolved or was created through
     /// `new`, this function does nothing.
     pub fn resolve(&mut self) {
+        // initialize dbghelp only once for all frames
+        #[cfg(all(windows, feature = "dbghelp"))]
+        let _c = unsafe { ::dbghelp_init() };
+
         for frame in self.frames.iter_mut().filter(|f| f.symbols.is_none()) {
             let mut symbols = Vec::new();
             resolve(frame.ip as *mut _, |symbol| {

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -68,6 +68,8 @@ impl Backtrace {
     /// ```
     #[inline(never)] // want to make sure there's a frame here to remove
     pub fn new() -> Backtrace {
+        let _lock = ::lock::lock();
+
         // initialize dbghelp only once for both the trace and the resolve
         #[cfg(all(windows, feature = "dbghelp"))]
         let _c = unsafe { ::dbghelp_init() };
@@ -145,6 +147,8 @@ impl Backtrace {
     /// If this backtrace has been previously resolved or was created through
     /// `new`, this function does nothing.
     pub fn resolve(&mut self) {
+        let _lock = ::lock::lock();
+
         // initialize dbghelp only once for all frames
         #[cfg(all(windows, feature = "dbghelp"))]
         let _c = unsafe { ::dbghelp_init() };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,11 +237,13 @@ mod dbghelp {
     }
 
     /// Tracks whether or not we have initialized dbghelp.dll inside of a call to `trace`.
+    #[cfg(feature = "std")]
     pub enum Trace {
         Inside(Option<Cleanup>),
         Outside,
     }
 
+    #[cfg(feature = "std")]
     thread_local! {
         pub static TRACE_CLEANUP: core::cell::RefCell<Trace> = core::cell::RefCell::new(Trace::Outside);
     }
@@ -280,5 +282,5 @@ mod dbghelp {
 #[cfg(all(windows, feature = "dbghelp"))]
 use dbghelp::init as dbghelp_init;
 
-#[cfg(all(windows, feature = "dbghelp"))]
+#[cfg(all(windows, feature = "dbghelp", feature = "std"))]
 use dbghelp::{Trace, TRACE_CLEANUP};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,17 @@ struct Cleanup {
 }
 
 #[cfg(all(windows, feature = "dbghelp"))]
+enum Trace {
+    Inside(Option<Cleanup>),
+    Outside,
+}
+
+thread_local! {
+    #[cfg(all(windows, feature = "dbghelp"))]
+    static TRACE_CLEANUP: std::cell::RefCell<Trace> = std::cell::RefCell::new(Trace::Outside);
+}
+
+#[cfg(all(windows, feature = "dbghelp"))]
 unsafe fn dbghelp_init() -> Option<Cleanup> {
     use winapi::shared::minwindef;
     use winapi::um::{dbghelp, processthreadsapi};
@@ -225,6 +236,19 @@ unsafe fn dbghelp_init() -> Option<Cleanup> {
                     dbghelp::SymCleanup(self.handle);
                     SymSetOptions(self.opts);
                 }
+            }
+        }
+    }
+
+    impl Clone for Cleanup {
+        fn clone(&self) -> Cleanup {
+            unsafe {
+                let mut ref_count_guard = (&*REF_COUNT).lock().unwrap();
+                *ref_count_guard += 1;
+            }
+            Cleanup {
+                opts: self.opts,
+                handle: self.handle
             }
         }
     }

--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -88,6 +88,7 @@ pub unsafe fn resolve(addr: *mut c_void, cb: &mut FnMut(&super::Symbol)) {
 
     let _c = ::dbghelp_init();
 
+    #[cfg(feature = "std")]
     ::TRACE_CLEANUP.with(|trace_cleanup| {
         use ::Trace;
         let mut trace_cleanup = trace_cleanup.borrow_mut();

--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -88,6 +88,18 @@ pub unsafe fn resolve(addr: *mut c_void, cb: &mut FnMut(&super::Symbol)) {
 
     let _c = ::dbghelp_init();
 
+    ::TRACE_CLEANUP.with(|trace_cleanup| {
+        use ::Trace;
+        let mut trace_cleanup = trace_cleanup.borrow_mut();
+        match *trace_cleanup {
+            Trace::Outside => {},
+            Trace::Inside(Some(_)) => {},
+            Trace::Inside(None) => {
+                *trace_cleanup = Trace::Inside(_c.clone());
+            }
+        }
+    });
+
     let mut displacement = 0u64;
     let ret = dbghelp::SymFromAddrW(processthreadsapi::GetCurrentProcess(),
                                     addr as DWORD64,

--- a/tests/long_fn_name.rs
+++ b/tests/long_fn_name.rs
@@ -23,7 +23,6 @@ mod _234567890_234567890_234567890_234567890_234567890 {
 #[test]
 #[cfg(all(windows, feature = "dbghelp", target_env = "msvc"))]
 fn test_long_fn_name() {
-    use winapi::um::dbghelp;
     use _234567890_234567890_234567890_234567890_234567890::
         _234567890_234567890_234567890_234567890_234567890 as S;
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -42,7 +42,10 @@ fn smoke_test_frames() {
         // On 32-bit windows apparently the first frame isn't our backtrace
         // frame but it's actually this frame. I'm not entirely sure why, but at
         // least it seems consistent?
-        let o = if cfg!(all(windows, target_pointer_width = "32")) {1} else {0};
+        let is_win32 = cfg!(all(windows, target_pointer_width = "32"));
+        let use_rtl_capture_backtrace = cfg!(feature = "kernel32");
+        let o = if is_win32 && !use_rtl_capture_backtrace {1} else {0};
+
         // frame offset 0 is the `backtrace::trace` function, but that's generic
         assert_frame(&v, o, 1, frame_4 as usize, "frame_4",
                      "tests/smoke.rs", start_line + 6);


### PR DESCRIPTION
This PR adds cleanup for `DbgHelp` so that the standard library can print backtraces on panic again. It now keeps count of the number of internal requests for initialization within a single API call in order to minimize the number of init/cleanup cycles. This helps to mitigate the additional overhead of pairing cleanup and initialization. In addition, dbghelp is now initialized with the `SYMOPT_DEFERRED_LOADS` to further reduce the cost of initialization. 

```
     Running target\release\deps\benchmarks-e36a49f193fde544.exe

running 6 tests
test new                                 ... bench:   5,853,185 ns/iter (+/- 329,515)
test new_unresolved                      ... bench:   4,646,070 ns/iter (+/- 359,873)
test new_unresolved_and_resolve_separate ... bench:   9,482,975 ns/iter (+/- 589,027)
test trace                               ... bench:   4,915,970 ns/iter (+/- 251,355)
test trace_and_resolve_callback          ... bench:   6,112,295 ns/iter (+/- 317,735)
test trace_and_resolve_separate          ... bench:  51,936,240 ns/iter (+/- 1,344,326)

test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured; 0 filtered out
```

Fixes #165