### PR TITLE
Pair SymCleanup with calls to SymInitializeW

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ std = []
 #   function to acquire a backtrace
 libunwind = []
 unix-backtrace = []
-dbghelp = ["std"]
+dbghelp = []
 kernel32 = []
 
 #=======================================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ std = []
 #   function to acquire a backtrace
 libunwind = []
 unix-backtrace = []
-dbghelp = []
+dbghelp = ["std"]
 kernel32 = []
 
 #=======================================

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,0 +1,96 @@
+#![feature(test)]
+
+extern crate test;
+
+extern crate backtrace;
+
+#[cfg(feature = "std")]
+use backtrace::Backtrace;
+
+#[bench]
+#[cfg(feature = "std")]
+fn trace(b: &mut test::Bencher) {
+    #[inline(never)]
+    fn the_function() {
+        backtrace::trace(|frame| {
+            let ip = frame.ip();
+            test::black_box(ip);
+            true
+        });
+    }
+    b.iter(the_function);
+}
+
+#[bench]
+#[cfg(feature = "std")]
+fn trace_and_resolve_callback(b: &mut test::Bencher) {
+    #[inline(never)]
+    fn the_function() {
+        backtrace::trace(|frame| {
+            backtrace::resolve(frame.ip(), |symbol| {
+                let addr = symbol.addr();
+                test::black_box(addr);
+            });
+            true
+        });
+    }
+    b.iter(the_function);
+}
+
+
+
+#[bench]
+#[cfg(feature = "std")]
+fn trace_and_resolve_separate(b: &mut test::Bencher) {
+    #[inline(never)]
+    fn the_function(frames: &mut Vec<*mut std::ffi::c_void>) {
+        backtrace::trace(|frame| {
+            frames.push(frame.ip());
+            true
+        });
+        frames.iter().for_each(|frame_ip| {
+            backtrace::resolve(*frame_ip, |symbol| {
+                test::black_box(symbol);
+            });
+        });
+    }
+    let mut frames = Vec::with_capacity(1024);
+    b.iter(|| {
+        the_function(&mut frames);
+        frames.clear();
+    });
+}
+
+#[bench]
+#[cfg(feature = "std")]
+fn new_unresolved(b: &mut test::Bencher) {
+    #[inline(never)]
+    fn the_function() {
+        let bt = Backtrace::new_unresolved();
+        test::black_box(bt);
+    }
+    b.iter(the_function);
+}
+
+#[bench]
+#[cfg(feature = "std")]
+fn new(b: &mut test::Bencher) {
+    #[inline(never)]
+    fn the_function() {
+        let bt = Backtrace::new();
+        test::black_box(bt);
+    }
+    b.iter(the_function);
+}
+
+#[bench]
+#[cfg(feature = "std")]
+fn new_unresolved_and_resolve_separate(b: &mut test::Bencher) {
+    #[inline(never)]
+    fn the_function() {
+        let mut bt = Backtrace::new_unresolved();
+        bt.resolve();
+        test::black_box(bt);
+    }
+    b.iter(the_function);
+}

--- a/src/backtrace/dbghelp.rs
+++ b/src/backtrace/dbghelp.rs
@@ -51,8 +51,11 @@ pub unsafe fn trace(cb: &mut FnMut(&super::Frame) -> bool) {
     };
     let image = init_frame(&mut frame.inner.inner, &context.0);
 
-    // Initialize this process's symbols
-    let _c = ::dbghelp_init();
+    // Ensure this process's symbols are initialized
+    let _cleanup = match ::dbghelp::init() {
+        Ok(cleanup) => cleanup,
+        Err(()) => return, // oh well...
+    };
 
     // And now that we're done with all the setup, do the stack walking!
     while dbghelp::StackWalk64(image as DWORD,

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -68,6 +68,10 @@ impl Backtrace {
     /// ```
     #[inline(never)] // want to make sure there's a frame here to remove
     pub fn new() -> Backtrace {
+        // initialize dbghelp only once for both the trace and the resolve
+        #[cfg(all(windows, feature = "dbghelp"))]
+        let _c = unsafe { ::dbghelp_init() };
+
         let mut bt = Self::create(Self::new as usize);
         bt.resolve();
         bt
@@ -141,6 +145,10 @@ impl Backtrace {
     /// If this backtrace has been previously resolved or was created through
     /// `new`, this function does nothing.
     pub fn resolve(&mut self) {
+        // initialize dbghelp only once for all frames
+        #[cfg(all(windows, feature = "dbghelp"))]
+        let _c = unsafe { ::dbghelp_init() };
+
         for frame in self.frames.iter_mut().filter(|f| f.symbols.is_none()) {
             let mut symbols = Vec::new();
             resolve(frame.ip as *mut _, |symbol| {

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -68,10 +68,6 @@ impl Backtrace {
     /// ```
     #[inline(never)] // want to make sure there's a frame here to remove
     pub fn new() -> Backtrace {
-        // initialize dbghelp only once for both the trace and the resolve
-        #[cfg(all(windows, feature = "dbghelp"))]
-        let _c = unsafe { ::dbghelp_init() };
-
         let mut bt = Self::create(Self::new as usize);
         bt.resolve();
         bt
@@ -145,10 +141,6 @@ impl Backtrace {
     /// If this backtrace has been previously resolved or was created through
     /// `new`, this function does nothing.
     pub fn resolve(&mut self) {
-        // initialize dbghelp only once for all frames
-        #[cfg(all(windows, feature = "dbghelp"))]
-        let _c = unsafe { ::dbghelp_init() };
-
         for frame in self.frames.iter_mut().filter(|f| f.symbols.is_none()) {
             let mut symbols = Vec::new();
             resolve(frame.ip as *mut _, |symbol| {

--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -86,7 +86,11 @@ pub unsafe fn resolve(addr: *mut c_void, cb: &mut FnMut(&super::Symbol)) {
     // due to struct alignment.
     info.SizeOfStruct = 88;
 
-    let _c = ::dbghelp_init();
+    // Ensure this process's symbols are initialized
+    let _cleanup = match ::dbghelp::init() {
+        Ok(cleanup) => cleanup,
+        Err(()) => return, // oh well...
+    };
 
     let mut displacement = 0u64;
     let ret = dbghelp::SymFromAddrW(processthreadsapi::GetCurrentProcess(),

--- a/tests/long_fn_name.rs
+++ b/tests/long_fn_name.rs
@@ -23,7 +23,6 @@ mod _234567890_234567890_234567890_234567890_234567890 {
 #[test]
 #[cfg(all(windows, feature = "dbghelp", target_env = "msvc"))]
 fn test_long_fn_name() {
-    use winapi::um::dbghelp;
     use _234567890_234567890_234567890_234567890_234567890::
         _234567890_234567890_234567890_234567890_234567890 as S;
 


### PR DESCRIPTION
This commit fixes https://github.com/alexcrichton/backtrace-rs/issues/165 by ensuring that we call `SymCleanup` on Windows. This additionally attempts to mitigate the accompanying performance loss by ensuring that we initialize/cleanup less often when called within scopes of this library. This is extracted from https://github.com/alexcrichton/backtrace-rs/pull/172 with some cleanup/refactoring.