### PR TITLE
Optionally use `StackWalkEx` if available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,3 +134,4 @@ required-features = ["std"]
 [[test]]
 name = "smoke"
 required-features = ["std"]
+edition = '2018'

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ fn main() {
         let symbol_address = frame.symbol_address();
 
         // Resolve this instruction pointer to a symbol name
-        backtrace::resolve(ip, |symbol| {
+        backtrace::resolve_frame(frame, |symbol| {
             if let Some(name) = symbol.name() {
                 // ...
             }

--- a/src/backtrace/dbghelp.rs
+++ b/src/backtrace/dbghelp.rs
@@ -17,17 +17,52 @@ use crate::dbghelp;
 use crate::dbghelp::ffi::*;
 use types::c_void;
 
-pub struct Frame {
-    inner: STACKFRAME64,
+#[derive(Clone, Copy)]
+pub enum Frame {
+    New(STACKFRAME_EX),
+    Old(STACKFRAME64),
 }
+
+// we're just sending around raw pointers and reading them, never interpreting
+// them so this should be safe to both send and share across threads.
+unsafe impl Send for Frame {}
+unsafe impl Sync for Frame {}
 
 impl Frame {
     pub fn ip(&self) -> *mut c_void {
-        self.inner.AddrPC.Offset as *mut _
+        self.addr_pc().Offset as *mut _
     }
 
     pub fn symbol_address(&self) -> *mut c_void {
         self.ip()
+    }
+
+    fn addr_pc(&self) -> &ADDRESS64 {
+        match self {
+            Frame::New(new) => &new.AddrPC,
+            Frame::Old(old) => &old.AddrPC,
+        }
+    }
+
+    fn addr_pc_mut(&mut self) -> &mut ADDRESS64 {
+        match self {
+            Frame::New(new) => &mut new.AddrPC,
+            Frame::Old(old) => &mut old.AddrPC,
+        }
+    }
+
+    fn addr_frame_mut(&mut self) -> &mut ADDRESS64 {
+        match self {
+            Frame::New(new) => &mut new.AddrFrame,
+            Frame::Old(old) => &mut old.AddrFrame,
+        }
+    }
+
+    fn addr_stack_mut(&mut self) -> &mut ADDRESS64 {
+        match self {
+            Frame::New(new) => &mut new.AddrStack,
+            Frame::Old(old) => &mut old.AddrStack,
+        }
     }
 }
 
@@ -42,12 +77,6 @@ pub unsafe fn trace(cb: &mut FnMut(&super::Frame) -> bool) {
 
     let mut context = mem::zeroed::<MyContext>();
     RtlCaptureContext(&mut context.0);
-    let mut frame = super::Frame {
-        inner: Frame {
-            inner: mem::zeroed(),
-        },
-    };
-    let image = init_frame(&mut frame.inner.inner, &context.0);
 
     // Ensure this process's symbols are initialized
     let dbghelp = match dbghelp::init() {
@@ -55,63 +84,100 @@ pub unsafe fn trace(cb: &mut FnMut(&super::Frame) -> bool) {
         Err(()) => return, // oh well...
     };
 
-    // And now that we're done with all the setup, do the stack walking!
-    while dbghelp.StackWalk64()(
-        image as DWORD,
-        process,
-        thread,
-        &mut frame.inner.inner,
-        &mut context.0 as *mut CONTEXT as *mut _,
-        None,
-        Some(dbghelp.SymFunctionTableAccess64()),
-        Some(dbghelp.SymGetModuleBase64()),
-        None,
-    ) == TRUE
-    {
-        if frame.inner.inner.AddrPC.Offset == frame.inner.inner.AddrReturn.Offset
-            || frame.inner.inner.AddrPC.Offset == 0
-            || frame.inner.inner.AddrReturn.Offset == 0
-        {
-            break;
-        }
+    // Attempt to use `StackWalkEx` if we can, but fall back to `StackWalk64`
+    // since it's in theory supported on more systems.
+    match (*dbghelp.dbghelp()).StackWalkEx() {
+        Some(StackWalkEx) => {
+            let mut frame = super::Frame {
+                inner: Frame::New(mem::zeroed()),
+            };
+            let image = init_frame(&mut frame.inner, &context.0);
+            let frame_ptr = match &mut frame.inner {
+                Frame::New(ptr) => ptr as *mut STACKFRAME_EX,
+                _ => unreachable!(),
+            };
 
-        if !cb(&frame) {
-            break;
+            while StackWalkEx(
+                image as DWORD,
+                process,
+                thread,
+                frame_ptr,
+                &mut context.0 as *mut CONTEXT as *mut _,
+                None,
+                Some(dbghelp.SymFunctionTableAccess64()),
+                Some(dbghelp.SymGetModuleBase64()),
+                None,
+                0,
+            ) == TRUE
+            {
+                if !cb(&frame) {
+                    break;
+                }
+            }
+        }
+        None => {
+            let mut frame = super::Frame {
+                inner: Frame::Old(mem::zeroed()),
+            };
+            let image = init_frame(&mut frame.inner, &context.0);
+            let frame_ptr = match &mut frame.inner {
+                Frame::Old(ptr) => ptr as *mut STACKFRAME64,
+                _ => unreachable!(),
+            };
+
+            while dbghelp.StackWalk64()(
+                image as DWORD,
+                process,
+                thread,
+                frame_ptr,
+                &mut context.0 as *mut CONTEXT as *mut _,
+                None,
+                Some(dbghelp.SymFunctionTableAccess64()),
+                Some(dbghelp.SymGetModuleBase64()),
+                None,
+            ) == TRUE
+            {
+                if !cb(&frame) {
+                    break;
+                }
+            }
         }
     }
 }
 
 #[cfg(target_arch = "x86_64")]
-fn init_frame(frame: &mut STACKFRAME64, ctx: &CONTEXT) -> WORD {
-    frame.AddrPC.Offset = ctx.Rip as u64;
-    frame.AddrPC.Mode = AddrModeFlat;
-    frame.AddrStack.Offset = ctx.Rsp as u64;
-    frame.AddrStack.Mode = AddrModeFlat;
-    frame.AddrFrame.Offset = ctx.Rbp as u64;
-    frame.AddrFrame.Mode = AddrModeFlat;
+fn init_frame(frame: &mut Frame, ctx: &CONTEXT) -> WORD {
+    frame.addr_pc_mut().Offset = ctx.Rip as u64;
+    frame.addr_pc_mut().Mode = AddrModeFlat;
+    frame.addr_stack_mut().Offset = ctx.Rsp as u64;
+    frame.addr_stack_mut().Mode = AddrModeFlat;
+    frame.addr_frame_mut().Offset = ctx.Rbp as u64;
+    frame.addr_frame_mut().Mode = AddrModeFlat;
+
     IMAGE_FILE_MACHINE_AMD64
 }
 
 #[cfg(target_arch = "x86")]
-fn init_frame(frame: &mut STACKFRAME64, ctx: &CONTEXT) -> WORD {
-    frame.AddrPC.Offset = ctx.Eip as u64;
-    frame.AddrPC.Mode = AddrModeFlat;
-    frame.AddrStack.Offset = ctx.Esp as u64;
-    frame.AddrStack.Mode = AddrModeFlat;
-    frame.AddrFrame.Offset = ctx.Ebp as u64;
-    frame.AddrFrame.Mode = AddrModeFlat;
+fn init_frame(frame: &mut Frame, ctx: &CONTEXT) -> WORD {
+    frame.addr_pc_mut().Offset = ctx.Eip as u64;
+    frame.addr_pc_mut().Mode = AddrModeFlat;
+    frame.addr_stack_mut().Offset = ctx.Esp as u64;
+    frame.addr_stack_mut().Mode = AddrModeFlat;
+    frame.addr_frame_mut().Offset = ctx.Ebp as u64;
+    frame.addr_frame_mut().Mode = AddrModeFlat;
+
     IMAGE_FILE_MACHINE_I386
 }
 
 #[cfg(target_arch = "aarch64")]
-fn init_frame(frame: &mut STACKFRAME64, ctx: &CONTEXT) -> WORD {
-    frame.AddrPC.Offset = ctx.Pc as u64;
-    frame.AddrPC.Mode = AddrModeFlat;
-    frame.AddrStack.Offset = ctx.Sp as u64;
-    frame.AddrStack.Mode = AddrModeFlat;
+fn init_frame(frame: &mut Frame, ctx: &CONTEXT) -> WORD {
+    frame.addr_pc_mut().Offset = ctx.Pc as u64;
+    frame.addr_pc_mut().Mode = AddrModeFlat;
+    frame.addr_stack_mut().Offset = ctx.Sp as u64;
+    frame.addr_stack_mut().Mode = AddrModeFlat;
     unsafe {
-        frame.AddrFrame.Offset = ctx.u.s().Fp as u64;
+        frame.addr_frame_mut().Offset = ctx.u.s().Fp as u64;
     }
-    frame.AddrFrame.Mode = AddrModeFlat;
+    frame.addr_frame_mut().Mode = AddrModeFlat;
     IMAGE_FILE_MACHINE_ARM64
 }

--- a/src/backtrace/noop.rs
+++ b/src/backtrace/noop.rs
@@ -3,6 +3,7 @@ use types::c_void;
 #[inline(always)]
 pub fn trace(_cb: &mut FnMut(&super::Frame) -> bool) {}
 
+#[derive(Clone)]
 pub struct Frame;
 
 impl Frame {

--- a/src/backtrace/unix_backtrace.rs
+++ b/src/backtrace/unix_backtrace.rs
@@ -13,16 +13,21 @@ use libc::c_int;
 
 use types::c_void;
 
+#[derive(Clone)]
 pub struct Frame {
-    addr: *mut c_void,
+    addr: usize,
 }
 
 impl Frame {
-    pub fn ip(&self) -> *mut c_void { self.addr }
-    pub fn symbol_address(&self) -> *mut c_void { self.addr }
+    pub fn ip(&self) -> *mut c_void {
+        self.addr as *mut c_void
+    }
+    pub fn symbol_address(&self) -> *mut c_void {
+        self.ip()
+    }
 }
 
-extern {
+extern "C" {
     fn backtrace(buf: *mut *mut c_void, sz: c_int) -> c_int;
 }
 
@@ -38,10 +43,12 @@ pub unsafe fn trace(cb: &mut FnMut(&super::Frame) -> bool) {
 
     for addr in buf[..cnt as usize].iter() {
         let cx = super::Frame {
-            inner: Frame { addr: *addr },
+            inner: Frame {
+                addr: *addr as usize,
+            },
         };
         if !cb(&cx) {
-            return
+            return;
         }
     }
 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,9 +1,9 @@
-use std::prelude::v1::*;
 use std::fmt;
 use std::path::{Path, PathBuf};
+use std::prelude::v1::*;
 
-use {trace, resolve, SymbolName};
 use types::c_void;
+use {resolve, resolve_frame, trace, Symbol, SymbolName};
 
 /// Representation of an owned and self-contained backtrace.
 ///
@@ -23,17 +23,42 @@ pub struct Backtrace {
     actual_start_index: usize,
 }
 
+fn _assert_send_sync() {
+    fn _assert<T: Send + Sync>() {}
+    _assert::<Backtrace>();
+}
+
 /// Captured version of a frame in a backtrace.
 ///
 /// This type is returned as a list from `Backtrace::frames` and represents one
 /// stack frame in a captured backtrace.
 #[derive(Clone)]
-#[cfg_attr(feature = "serialize-rustc", derive(RustcDecodable, RustcEncodable))]
-#[cfg_attr(feature = "serialize-serde", derive(Deserialize, Serialize))]
 pub struct BacktraceFrame {
-    ip: usize,
-    symbol_address: usize,
+    frame: Frame,
     symbols: Option<Vec<BacktraceSymbol>>,
+}
+
+#[derive(Clone)]
+enum Frame {
+    Raw(::Frame),
+    #[allow(dead_code)]
+    Deserialized { ip: usize, symbol_address: usize },
+}
+
+impl Frame {
+    fn ip(&self) -> *mut c_void {
+        match *self {
+            Frame::Raw(ref f) => f.ip(),
+            Frame::Deserialized { ip, .. } => ip as *mut c_void,
+        }
+    }
+
+    fn symbol_address(&self) -> *mut c_void {
+        match *self {
+            Frame::Raw(ref f) => f.symbol_address(),
+            Frame::Deserialized { symbol_address, .. } => symbol_address as *mut c_void,
+        }
+    }
 }
 
 /// Captured version of a symbol in a backtrace.
@@ -107,15 +132,14 @@ impl Backtrace {
         trace(|frame| {
             let ip = frame.ip() as usize;
             frames.push(BacktraceFrame {
-                ip,
-                symbol_address: frame.symbol_address() as usize,
+                frame: Frame::Raw(frame.clone()),
                 symbols: None,
             });
 
-            if cfg!(not(all(target_os = "windows", target_arch = "x86"))) &&
-                ip >= ip_lo &&
-                ip <= ip_hi &&
-                actual_start_index.is_none()
+            if cfg!(not(all(target_os = "windows", target_arch = "x86")))
+                && ip >= ip_lo
+                && ip <= ip_hi
+                && actual_start_index.is_none()
             {
                 actual_start_index = Some(frames.len());
             }
@@ -146,14 +170,22 @@ impl Backtrace {
         let _guard = lock_and_platform_init();
         for frame in self.frames.iter_mut().filter(|f| f.symbols.is_none()) {
             let mut symbols = Vec::new();
-            resolve(frame.ip as *mut _, |symbol| {
-                symbols.push(BacktraceSymbol {
-                    name: symbol.name().map(|m| m.as_bytes().to_vec()),
-                    addr: symbol.addr().map(|a| a as usize),
-                    filename: symbol.filename().map(|m| m.to_owned()),
-                    lineno: symbol.lineno(),
-                });
-            });
+            {
+                let sym = |symbol: &Symbol| {
+                    symbols.push(BacktraceSymbol {
+                        name: symbol.name().map(|m| m.as_bytes().to_vec()),
+                        addr: symbol.addr().map(|a| a as usize),
+                        filename: symbol.filename().map(|m| m.to_owned()),
+                        lineno: symbol.lineno(),
+                    });
+                };
+                match frame.frame {
+                    Frame::Raw(ref f) => resolve_frame(f, sym),
+                    Frame::Deserialized { ip, .. } => {
+                        resolve(ip as *mut c_void, sym);
+                    }
+                }
+            }
             frame.symbols = Some(symbols);
         }
     }
@@ -177,12 +209,12 @@ impl Into<Vec<BacktraceFrame>> for Backtrace {
 impl BacktraceFrame {
     /// Same as `Frame::ip`
     pub fn ip(&self) -> *mut c_void {
-        self.ip as *mut c_void
+        self.frame.ip() as *mut c_void
     }
 
     /// Same as `Frame::symbol_address`
     pub fn symbol_address(&self) -> *mut c_void {
-        self.symbol_address as *mut c_void
+        self.frame.symbol_address() as *mut c_void
     }
 
     /// Returns the list of symbols that this frame corresponds to.
@@ -254,7 +286,7 @@ impl fmt::Debug for Backtrace {
                 Some(ref s) => s,
                 None => {
                     write!(fmt, "<unresolved> ({:?})", ip)?;
-                    continue
+                    continue;
                 }
             };
             if symbols.len() == 0 {
@@ -290,6 +322,26 @@ impl fmt::Debug for Backtrace {
 impl Default for Backtrace {
     fn default() -> Backtrace {
         Backtrace::new()
+    }
+}
+
+impl fmt::Debug for BacktraceFrame {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("BacktraceFrame")
+            .field("ip", &self.ip())
+            .field("symbol_address", &self.symbol_address())
+            .finish()
+    }
+}
+
+impl fmt::Debug for BacktraceSymbol {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("BacktraceSymbol")
+            .field("name", &self.name())
+            .field("addr", &self.addr())
+            .field("filename", &self.filename())
+            .field("lineno", &self.lineno())
+            .finish()
     }
 }
 
@@ -337,3 +389,95 @@ fn lock_and_platform_init() -> impl Drop {
 
 #[cfg(not(all(windows, feature = "dbghelp")))]
 fn lock_and_platform_init() {}
+
+#[cfg(feature = "serialize-rustc")]
+mod rustc_serialize_impls {
+    use super::*;
+    use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+
+    #[derive(RustcEncodable, RustcDecodable)]
+    struct SerializedFrame {
+        ip: usize,
+        symbol_address: usize,
+        symbols: Option<Vec<BacktraceSymbol>>,
+    }
+
+    impl Decodable for BacktraceFrame {
+        fn decode<D>(d: &mut D) -> Result<Self, D::Error>
+        where
+            D: Decoder,
+        {
+            let frame: SerializedFrame = SerializedFrame::decode(d)?;
+            Ok(BacktraceFrame {
+                frame: Frame::Deserialized {
+                    ip: frame.ip,
+                    symbol_address: frame.symbol_address,
+                },
+                symbols: frame.symbols,
+            })
+        }
+    }
+
+    impl Encodable for BacktraceFrame {
+        fn encode<E>(&self, e: &mut E) -> Result<(), E::Error>
+        where
+            E: Encoder,
+        {
+            let BacktraceFrame { frame, symbols } = self;
+            SerializedFrame {
+                ip: frame.ip() as usize,
+                symbol_address: frame.symbol_address() as usize,
+                symbols: symbols.clone(),
+            }
+            .encode(e)
+        }
+    }
+}
+
+#[cfg(feature = "serialize-serde")]
+mod serde_impls {
+    extern crate serde;
+
+    use self::serde::de::Deserializer;
+    use self::serde::ser::Serializer;
+    use self::serde::{Deserialize, Serialize};
+    use super::*;
+
+    #[derive(Serialize, Deserialize)]
+    struct SerializedFrame {
+        ip: usize,
+        symbol_address: usize,
+        symbols: Option<Vec<BacktraceSymbol>>,
+    }
+
+    impl Serialize for BacktraceFrame {
+        fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let BacktraceFrame { frame, symbols } = self;
+            SerializedFrame {
+                ip: frame.ip() as usize,
+                symbol_address: frame.symbol_address() as usize,
+                symbols: symbols.clone(),
+            }
+            .serialize(s)
+        }
+    }
+
+    impl<'a> Deserialize<'a> for BacktraceFrame {
+        fn deserialize<D>(d: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'a>,
+        {
+            let frame: SerializedFrame = SerializedFrame::deserialize(d)?;
+            Ok(BacktraceFrame {
+                frame: Frame::Deserialized {
+                    ip: frame.ip,
+                    symbol_address: frame.symbol_address,
+                },
+                symbols: frame.symbols,
+            })
+        }
+    }
+}

--- a/src/dbghelp/ffi.rs
+++ b/src/dbghelp/ffi.rs
@@ -37,6 +37,7 @@ macro_rules! ffi {
     (#[repr($($r:tt)*)] pub struct $name:ident { $(pub $field:ident: $ty:ty,)* } $($rest:tt)*) => (
         #[repr($($r)*)]
         #[cfg(not(feature = "verify-winapi"))]
+        #[derive(Copy, Clone)]
         pub struct $name {
             $(pub $field: $ty,)*
         }
@@ -152,10 +153,10 @@ macro_rules! ffi {
         $(
             #[cfg(feature = "verify-winapi")]
             mod $name {
-                use super::*;
-
                 #[test]
                 fn assert_same() {
+                    use super::*;
+
                     assert_eq!($name as usize, winapi::$name as usize);
                     let mut x: unsafe extern "system" fn($($args)*) -> $ret;
                     x = $name;
@@ -196,6 +197,25 @@ ffi! {
     }
 
     pub type LPSTACKFRAME64 = *mut STACKFRAME64;
+
+    #[repr(C)]
+    pub struct STACKFRAME_EX {
+        pub AddrPC: ADDRESS64,
+        pub AddrReturn: ADDRESS64,
+        pub AddrFrame: ADDRESS64,
+        pub AddrStack: ADDRESS64,
+        pub AddrBStore: ADDRESS64,
+        pub FuncTableEntry: PVOID,
+        pub Params: [DWORD64; 4],
+        pub Far: BOOL,
+        pub Virtual: BOOL,
+        pub Reserved: [DWORD64; 3],
+        pub KdHelp: KDHELP64,
+        pub StackFrameSize: DWORD,
+        pub InlineFrameContext: DWORD,
+    }
+
+    pub type LPSTACKFRAME_EX = *mut STACKFRAME_EX;
 
     #[repr(C)]
     pub struct IMAGEHLP_LINEW64 {
@@ -497,6 +517,7 @@ ffi! {
 
 #[repr(C)]
 #[cfg(target_arch = "x86_64")]
+#[derive(Copy, Clone)]
 pub struct FLOATING_SAVE_AREA {
     _Dummy: [u8; 512],
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //!         let symbol_address = frame.symbol_address();
 //!
 //!         // Resolve this instruction pointer to a symbol name
-//!         backtrace::resolve(ip, |symbol| {
+//!         backtrace::resolve_frame(frame, |symbol| {
 //!             if let Some(name) = symbol.name() {
 //!                 // ...
 //!             }
@@ -114,6 +114,7 @@ pub use backtrace::{trace_unsynchronized, Frame};
 mod backtrace;
 
 pub use symbolize::{resolve_unsynchronized, Symbol, SymbolName};
+pub use symbolize::resolve_frame_unsynchronized;
 mod symbolize;
 
 pub use types::BytesOrWideString;
@@ -122,7 +123,7 @@ mod types;
 cfg_if! {
     if #[cfg(feature = "std")] {
         pub use backtrace::trace;
-        pub use symbolize::resolve;
+        pub use symbolize::{resolve, resolve_frame};
         pub use capture::{Backtrace, BacktraceFrame, BacktraceSymbol};
         mod capture;
     }

--- a/src/symbolize/coresymbolication.rs
+++ b/src/symbolize/coresymbolication.rs
@@ -21,6 +21,7 @@ use SymbolName;
 use dylib::Dylib;
 use dylib::Symbol as DylibSymbol;
 use types::{BytesOrWideString, c_void};
+use symbolize::ResolveWhat;
 
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq)]
@@ -177,7 +178,8 @@ unsafe fn try_resolve(addr: *mut c_void, cb: &mut FnMut(&super::Symbol)) -> bool
     rv
 }
 
-pub unsafe fn resolve(addr: *mut c_void, cb: &mut FnMut(&super::Symbol)) {
+pub unsafe fn resolve(what: ResolveWhat, cb: &mut FnMut(&super::Symbol)) {
+    let addr = what.address_or_ip();
     if try_resolve(addr, cb) {
         return
     }

--- a/src/symbolize/dladdr.rs
+++ b/src/symbolize/dladdr.rs
@@ -12,6 +12,7 @@ use core::{mem, slice};
 
 use types::{BytesOrWideString, c_void};
 use libc::{self, Dl_info};
+use symbolize::ResolveWhat;
 
 use SymbolName;
 
@@ -45,7 +46,8 @@ impl Symbol {
     }
 }
 
-pub unsafe fn resolve(addr: *mut c_void, cb: &mut FnMut(&super::Symbol)) {
+pub unsafe fn resolve(what: ResolveWhat, cb: &mut FnMut(&super::Symbol)) {
+    let addr = what.address_or_ip();
     let mut info: super::Symbol = super::Symbol {
         inner: Symbol {
             inner: mem::zeroed(),

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -13,6 +13,7 @@ use std::prelude::v1::*;
 
 use SymbolName;
 use types::BytesOrWideString;
+use symbolize::ResolveWhat;
 
 const MAPPINGS_CACHE_SIZE: usize = 4;
 
@@ -107,7 +108,9 @@ where
     });
 }
 
-pub fn resolve(addr: *mut c_void, cb: &mut FnMut(&super::Symbol)) {
+pub fn resolve(what: ResolveWhat, cb: &mut FnMut(&super::Symbol)) {
+    let addr = what.address_or_ip();
+
     // First, find the file containing the segment that the given AVMA (after
     // relocation) address falls within. Use the containing segment to compute
     // the SVMA (before relocation) address.

--- a/src/symbolize/libbacktrace.rs
+++ b/src/symbolize/libbacktrace.rs
@@ -21,6 +21,7 @@ use libc::{self, c_char, c_int, c_void, uintptr_t};
 use SymbolName;
 
 use types::BytesOrWideString;
+use symbolize::ResolveWhat;
 
 pub enum Symbol {
     Syminfo {
@@ -160,8 +161,9 @@ unsafe fn init_state() -> *mut bt::backtrace_state {
     STATE
 }
 
-pub unsafe fn resolve(symaddr: *mut c_void, mut cb: &mut FnMut(&super::Symbol))
-{
+pub unsafe fn resolve(what: ResolveWhat, mut cb: &mut FnMut(&super::Symbol)) {
+    let symaddr = what.address_or_ip();
+
     // backtrace errors are currently swept under the rug
     let state = init_state();
     if state.is_null() {

--- a/src/symbolize/noop.rs
+++ b/src/symbolize/noop.rs
@@ -1,7 +1,8 @@
 use types::{BytesOrWideString, c_void};
 use SymbolName;
+use symbolize::ResolveWhat;
 
-pub unsafe fn resolve(_addr: *mut c_void, _cb: &mut FnMut(&super::Symbol)) {
+pub unsafe fn resolve(_addr: ResolveWhat, _cb: &mut FnMut(&super::Symbol)) {
 }
 
 pub struct Symbol;


### PR DESCRIPTION
This helps recover inline frames in addition to normal frames when
generating a backtrace. This involved quite a few changes because the
`resolve` function now also needed more auxiliary information than just
the address pointer. Instead now there's an optional API for resolving
with a `Frame` which plumbs through all the right information to get
resolved correctly. The `Backtrace` API now stores clones of `Frame`
(and `Frame` now implements `Clone`) to resolve these frames fully.