### PR TITLE
Add support for libbacktrace on MinGW

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ autotests = true
 cfg-if = "0.1.6"
 rustc-demangle = "0.1.4"
 backtrace-sys = { path = "backtrace-sys", version = "0.1.17", optional = true }
+libc = { version = "0.2.45", default-features = false }
 
 # Optionally enable the ability to serialize a `Backtrace`
 serde = { version = "1.0", optional = true }
@@ -31,9 +32,6 @@ cpp_demangle = { default-features = false, version = "0.2.3", optional = true }
 addr2line = { version = "0.9.0", optional = true }
 findshlibs = { version = "0.4.1", optional = true }
 memmap = { version = "0.7.0", optional = true }
-
-[target.'cfg(not(windows))'.dependencies]
-libc = { version = "0.2.45", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.3", optional = true }
@@ -100,10 +98,12 @@ gimli-symbolize = ["addr2line", "findshlibs", "memmap" ]
 # Internal feature to this crate, only used when testing this crate
 verify-winapi = [
   'winapi/dbghelp',
-  'winapi/processthreadsapi',
-  'winapi/winnt',
-  'winapi/minwindef',
+  'winapi/handleapi',
   'winapi/libloaderapi',
+  'winapi/minwindef',
+  'winapi/processthreadsapi',
+  'winapi/winbase',
+  'winapi/winnt',
 ]
 
 #=======================================

--- a/src/backtrace/dbghelp.rs
+++ b/src/backtrace/dbghelp.rs
@@ -13,8 +13,8 @@
 use core::mem;
 use core::prelude::v1::*;
 
-use crate::dbghelp;
-use crate::dbghelp::ffi::*;
+use dbghelp;
+use windows::*;
 use types::c_void;
 
 #[derive(Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,6 @@
 #[macro_use]
 extern crate std;
 
-#[cfg(any(unix, target_env = "sgx"))]
 extern crate libc;
 #[cfg(all(windows, feature = "verify-winapi"))]
 extern crate winapi;
@@ -183,3 +182,5 @@ mod lock {
 
 #[cfg(all(windows, feature = "dbghelp"))]
 mod dbghelp;
+#[cfg(windows)]
+mod windows;

--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -25,9 +25,9 @@ use core::slice;
 
 use backtrace::FrameImp as Frame;
 use dbghelp;
-use dbghelp::ffi::*;
 use symbolize::ResolveWhat;
 use types::{c_void, BytesOrWideString};
+use windows::*;
 use SymbolName;
 
 // Store an OsString on std so we can provide the symbol name and filename.
@@ -122,22 +122,8 @@ unsafe fn resolve_without_inline(
     cb: &mut FnMut(&super::Symbol),
 ) {
     do_resolve(
-        |info| {
-            dbghelp.SymFromAddrW()(
-                GetCurrentProcess(),
-                addr as DWORD64,
-                &mut 0,
-                info,
-            )
-        },
-        |line| {
-            dbghelp.SymGetLineFromAddrW64()(
-                GetCurrentProcess(),
-                addr as DWORD64,
-                &mut 0,
-                line,
-            )
-        },
+        |info| dbghelp.SymFromAddrW()(GetCurrentProcess(), addr as DWORD64, &mut 0, info),
+        |line| dbghelp.SymGetLineFromAddrW64()(GetCurrentProcess(), addr as DWORD64, &mut 0, line),
         cb,
     )
 }

--- a/src/symbolize/libbacktrace.rs
+++ b/src/symbolize/libbacktrace.rs
@@ -84,11 +84,22 @@ impl Symbol {
 
     #[cfg(feature = "std")]
     pub fn filename(&self) -> Option<&::std::path::Path> {
-        use std::ffi::OsStr;
-        use std::os::unix::prelude::*;
         use std::path::Path;
 
-        self.filename_bytes().map(OsStr::from_bytes).map(Path::new)
+        #[cfg(unix)]
+        fn bytes2path(bytes: &[u8]) -> Option<&Path> {
+            use std::ffi::OsStr;
+            use std::os::unix::prelude::*;
+            Some(Path::new(OsStr::from_bytes(bytes)))
+        }
+
+        #[cfg(windows)]
+        fn bytes2path(bytes: &[u8]) -> Option<&Path> {
+            use std::str;
+            str::from_utf8(bytes).ok().map(Path::new)
+        }
+
+        self.filename_bytes().and_then(bytes2path)
     }
 
     pub fn lineno(&self) -> Option<u32> {
@@ -192,23 +203,25 @@ unsafe fn init_state() -> *mut bt::backtrace_state {
     // number of mechanisms including, but not limited to:
     //
     // * /proc/self/exe on supported platforms
-    // * The filename passed in below
+    // * The filename passed in explicitly when creating state
     //
     // The libbacktrace library is a big wad of C code. This naturally means
     // it's got memory safety vulnerabilities, especially when handling
     // malformed debuginfo. Libstd has run into plenty of these historically.
     //
-    // Turns out that if we pass in a filename here it's possible on some
-    // platforms (like BSDs) where a malicious actor can cause an arbitrary file
-    // to be placed at that location. This means that if we tell libbacktrace
-    // about a filename it may be using an arbitrary file, possibly causing
-    // segfaults. If we don't tell libbacktrace anything though then it won't do
-    // anything on platforms that don't support paths like /proc/self/exe!
+    // If /proc/self/exe is used then we can typically ignore these as we
+    // assume that libbacktrace is "mostly correct" and otherwise doesn't do
+    // weird things with "attempted to be correct" dwarf debug info.
     //
-    // As a result we only, on some platforms, pass an explicit filename.
-    // Currently this is only what OSX does to match what libstd does, as the
-    // probing logic in libbacktrace is thought to be "good enough". Eventually
-    // we'll want to switch to a 100% safe version like gimli...
+    // If we pass in a filename, however, then it's possible on some platforms
+    // (like BSDs) where a malicious actor can cause an arbitrary file to be
+    // placed at that location. This means that if we tell libbacktrace about a
+    // filename it may be using an arbitrary file, possibly causing segfaults.
+    // If we don't tell libbacktrace anything though then it won't do anything
+    // on platforms that don't support paths like /proc/self/exe!
+    //
+    // Given all that we try as hard as possible to *not* pass in a filename,
+    // but we must on platforms that don't support /proc/self/exe at all.
     cfg_if! {
         if #[cfg(any(target_os = "macos", target_os = "ios"))] {
             // Note that ideally we'd use `std::env::current_exe`, but we can't
@@ -236,6 +249,83 @@ unsafe fn init_state() -> *mut bt::backtrace_state {
                     ptr::null()
                 }
             }
+        } else if #[cfg(windows)] {
+            use windows::*;
+
+            // Windows has a mode of opening files where after it's opened it
+            // can't be deleted. That's in general what we want here because we
+            // want to ensure that our executable isn't changing out from under
+            // us after we hand it off to libbacktrace, hopefully mitigating the
+            // ability to pass in arbitrary data into libbacktrace (which may be
+            // mishandled).
+            //
+            // Given that we do a bit of a dance here to attempt to get a sort
+            // of lock on our own image:
+            //
+            // * Get a handle to the current process, load its filename.
+            // * Open a file to that filename with the right flags.
+            // * Reload the current process's filename, making sure it's the same
+            //
+            // If that all passes we in theory have indeed opened our process's
+            // file and we're guaranteed it won't change. FWIW a bunch of this
+            // is copied from libstd historically, so this is my best
+            // interpretation of what was happening.
+            unsafe fn load_filename() -> *const libc::c_char {
+                load_filename_opt().unwrap_or(ptr::null())
+            }
+
+            unsafe fn load_filename_opt() -> Result<*const libc::c_char, ()> {
+                const N: usize = 256;
+                // This lives in static memory so we can return it..
+                static mut BUF: [i8; N] = [0; N];
+                // ... and this lives on the stack since it's temporary
+                let mut stack_buf = [0; N];
+                let name1 = query_full_name(&mut BUF)?;
+
+                let handle = CreateFileA(
+                    name1.as_ptr(),
+                    GENERIC_READ,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE,
+                    ptr::null_mut(),
+                    OPEN_EXISTING,
+                    0,
+                    ptr::null_mut(),
+                );
+                if handle.is_null() {
+                    return Err(());
+                }
+
+                let name2 = query_full_name(&mut stack_buf)?;
+                if name1 != name2 {
+                    CloseHandle(handle);
+                    return Err(())
+                }
+                // intentionally leak `handle` here because having that open
+                // should preserve our lock on this file name.
+                Ok(name1.as_ptr())
+            }
+
+            unsafe fn query_full_name(buf: &mut [i8]) -> Result<&[i8], ()> {
+                let p1 = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, GetCurrentProcessId());
+                let mut len = buf.len() as u32;
+                let rc = QueryFullProcessImageNameA(p1, 0, buf.as_mut_ptr(), &mut len);
+                CloseHandle(p1);
+
+                // We want to return a slice that is nul-terminated, so if
+                // everything was filled in and it equals the total length
+                // then equate that to failure.
+                //
+                // Otherwise when returning success make sure the nul byte is
+                // included in the slice.
+                if rc == 0 || len == buf.len() as u32 {
+                    Err(())
+                } else {
+                    assert_eq!(buf[len as usize], 0);
+                    Ok(&buf[..(len + 1) as usize])
+                }
+            }
+
+
         } else {
             unsafe fn load_filename() -> *const libc::c_char {
                 ptr::null()

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -381,7 +381,7 @@ cfg_if! {
 }
 
 cfg_if! {
-    if #[cfg(all(windows, feature = "dbghelp"))] {
+    if #[cfg(all(windows, target_env = "msvc", feature = "dbghelp"))] {
         mod dbghelp;
         use self::dbghelp::resolve as resolve_imp;
         use self::dbghelp::Symbol as SymbolImp;
@@ -402,7 +402,7 @@ cfg_if! {
         use self::coresymbolication::resolve as resolve_imp;
         use self::coresymbolication::Symbol as SymbolImp;
     } else if #[cfg(all(feature = "libbacktrace",
-                        unix,
+                        any(unix, all(windows, target_env = "gnu")),
                         not(target_os = "fuchsia"),
                         not(target_os = "emscripten")))] {
         mod libbacktrace;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -14,20 +14,26 @@ cfg_if! {
         pub use self::winapi::c_void;
         pub use self::winapi::HINSTANCE;
         pub use self::winapi::FARPROC;
+        pub use self::winapi::LPSECURITY_ATTRIBUTES;
 
         mod winapi {
             pub use winapi::ctypes::*;
             pub use winapi::shared::basetsd::*;
             pub use winapi::shared::minwindef::*;
             pub use winapi::um::dbghelp::*;
-            pub use winapi::um::winnt::*;
+            pub use winapi::um::handleapi::*;
             pub use winapi::um::libloaderapi::*;
             pub use winapi::um::processthreadsapi::*;
+            pub use winapi::um::winbase::*;
+            pub use winapi::um::winnt::*;
+            pub use winapi::um::fileapi::*;
+            pub use winapi::um::minwinbase::*;
         }
     } else {
         pub use core::ffi::c_void;
         pub type HINSTANCE = *mut c_void;
         pub type FARPROC = *mut c_void;
+        pub type LPSECURITY_ATTRIBUTES = *mut c_void;
     }
 }
 
@@ -298,9 +304,15 @@ ffi! {
     pub const MAX_SYM_NAME: usize = 2000;
     pub const AddrModeFlat: ADDRESS_MODE = 3;
     pub const TRUE: BOOL = 1;
+    pub const FALSE: BOOL = 0;
+    pub const PROCESS_QUERY_INFORMATION: DWORD = 0x400;
     pub const IMAGE_FILE_MACHINE_ARM64: u16 = 43620;
     pub const IMAGE_FILE_MACHINE_AMD64: u16 = 34404;
     pub const IMAGE_FILE_MACHINE_I386: u16 = 332;
+    pub const FILE_SHARE_READ: DWORD = 0x1;
+    pub const FILE_SHARE_WRITE: DWORD = 0x2;
+    pub const OPEN_EXISTING: DWORD = 0x3;
+    pub const GENERIC_READ: DWORD = 0x80000000;
 
     pub type DWORD = u32;
     pub type PDWORD = *mut u32;
@@ -310,6 +322,8 @@ ffi! {
     pub type HANDLE = *mut c_void;
     pub type PVOID = HANDLE;
     pub type PCWSTR = *const u16;
+    pub type LPSTR = *mut i8;
+    pub type LPCSTR = *const i8;
     pub type PWSTR = *mut u16;
     pub type WORD = u16;
     pub type ULONG = u32;
@@ -327,6 +341,28 @@ ffi! {
         pub fn LoadLibraryW(a: *const u16) -> HMODULE;
         pub fn FreeLibrary(h: HMODULE) -> BOOL;
         pub fn GetProcAddress(h: HMODULE, name: *const i8) -> FARPROC;
+        pub fn OpenProcess(
+            dwDesiredAccess: DWORD,
+            bInheitHandle: BOOL,
+            dwProcessId: DWORD,
+        ) -> HANDLE;
+        pub fn GetCurrentProcessId() -> DWORD;
+        pub fn CloseHandle(h: HANDLE) -> BOOL;
+        pub fn QueryFullProcessImageNameA(
+            hProcess: HANDLE,
+            dwFlags: DWORD,
+            lpExeName: LPSTR,
+            lpdwSize: PDWORD,
+        ) -> BOOL;
+        pub fn CreateFileA(
+            lpFileName: LPCSTR,
+            dwDesiredAccess: DWORD,
+            dwShareMode: DWORD,
+            lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
+            dwCreationDisposition: DWORD,
+            dwFlagsAndAttributes: DWORD,
+            hTemplateFile: HANDLE,
+        ) -> HANDLE;
     }
 }
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -5,7 +5,7 @@ use std::thread;
 
 static LIBUNWIND: bool = cfg!(all(unix, feature = "libunwind"));
 static UNIX_BACKTRACE: bool = cfg!(all(unix, feature = "unix-backtrace"));
-static LIBBACKTRACE: bool = cfg!(all(unix, feature = "libbacktrace"))
+static LIBBACKTRACE: bool = cfg!(feature = "libbacktrace")
     && !cfg!(target_os = "fuchsia");
 static CORESYMBOLICATION: bool = cfg!(all(
     any(target_os = "macos", target_os = "ios"),


### PR DESCRIPTION
This commit adds support to use libbacktrace for symbolication on MinGW
and switches to it by default since dbghelp doesn't really work on MinGW
anyway.

This largely involvse juggling a few dependencies around but
additionally adding support to the `libbacktrace.rs` module for loading
the filename of the current image on Windows.